### PR TITLE
add script to download and prepare SOAP TCK tests

### DIFF
--- a/soap-tck/README.md
+++ b/soap-tck/README.md
@@ -1,0 +1,4 @@
+Information:
+https://jakarta.ee/specifications/soap-attachments/3.0/
+
+Modify `run-tck.sh` -- replace webcontainer.home with the directory of your Payara.

--- a/soap-tck/run-tck.sh
+++ b/soap-tck/run-tck.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+if [ JAVA_HOME = "" ] ; then
+    export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+fi
+export TS_HOME=`pwd`/soap-tck
+#/home/aubi/work/payara/server/defects/FISH-6064-upgrade-metro/soap-tck
+export PATH=${PATH}:${TS_HOME}/bin
+
+rm jakarta-soap-tck-3.0.0.zip
+wget https://download.eclipse.org/jakartaee/soap-attachments/3.0/jakarta-soap-tck-3.0.0.zip
+rm -rf ./soap-tck
+unzip jakarta-soap-tck-3.0.0.zip
+
+# replace settings
+if [[ ! -f ${TS_HOME}/bin/ts.jte-origin ]]
+then
+    mv ${TS_HOME}/bin/ts.jte ${TS_HOME}/bin/ts.jte-origin
+fi
+sed "s/^webcontainer.home=\$/webcontainer.home=\/home\/aubi\/work\/payara\/server\/Payara-src-fork\/appserver\/distributions\/payara\/target\/stage\/payara6\/glassfish/" ${TS_HOME}/bin/ts.jte-origin > ${TS_HOME}/bin/ts.jte-temp1
+sed "s/^local.classes=\$/local.classes=\${webcontainer.home}\/modules\/webservices-api-osgi.jar:\${webcontainer.home}\/modules\/webservices-osgi.jar:\${webcontainer.home}\/modules\/jakarta.activation-api.jar:\${webcontainer.home}\/modules\/jaxb-osgi.jar/" ${TS_HOME}/bin/ts.jte-temp1 > ${TS_HOME}/bin/ts.jte-temp2
+
+mv ${TS_HOME}/bin/ts.jte-temp2 ${TS_HOME}/bin/ts.jte
+
+cd ${TS_HOME}/bin
+ant config.vi
+
+ant deploy.all
+
+ant gui


### PR DESCRIPTION
SOAP TCK is based on JT, e.g. not Arquillian.
This script downloads TCK, unpacks and prepares variables. The only place to edit is the directory of local Payara.