### PR TITLE
FISH-6448 Batch TCK Runner

### DIFF
--- a/batch-tck/README.md
+++ b/batch-tck/README.md
@@ -14,22 +14,25 @@ SPDX-License-Identifier: Apache-2.0
 
 # Executing Jakarta Batch TCK against Payara
 
-To run the full TCK against Payara Server using the managed Arquillian container, execute:
+To run the full TCK against Payara Server using the managed Arquillian container, first edit the pom and define your payara.version.
+You **CANNOT** simply override this with `-Dpayara.version` - Shrinkwrap will ignore this and **ALWAYS** read the pom as-is.
+
+Once you have defined your payara version, execute:
 
 ```
-mvn clean verify -Dpayara.version=xyz
+mvn clean verify
 ```
 
 To run the full TCK against Payara Server using remote Arquillian container, activate the `payara-server-remote` profile and specify `payara.home`:
 
 ```
-mvn clean verify -Dpayara.version=xyz -Dpayara.home=/path/to/payara6 -Ppayara-server-remote
+mvn clean verify -Dpayara.home=/path/to/payara6 -Ppayara-server-remote
 ```
 
 If you wish to skip the test setup (for example if re-running against a remote server), add the `-Dskip.setup` property:
 
 ```
-mvn clean verify -Dpayara.version=xyz -Dpayara.home=/path/to/payara6 -Dskip.setup -Ppayara-server-remote
+mvn clean verify -Dpayara.home=/path/to/payara6 -Dskip.setup -Ppayara-server-remote
 ```
 
 ## Details

--- a/batch-tck/README.md
+++ b/batch-tck/README.md
@@ -1,0 +1,40 @@
+<!--- 
+Copyright (c) 2022 Contributors to the Eclipse Foundation
+
+See the NOTICE file distributed with this work for additional information regarding copyright 
+ownership. Licensed under the Apache License, Version 2.0 (the "License"); 
+you may not use this file except in compliance with the License. You may 
+obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+Unless required by applicable law or agreed to in writing, software distributed 
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
+OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
+the specific language governing permissions and limitations under the License. 
+SPDX-License-Identifier: Apache-2.0
+--->
+
+# Executing Jakarta Batch TCK against Payara
+
+To run the full TCK against Payara Server using the managed Arquillian container, execute:
+
+```
+mvn clean verify -Dpayara.version=xyz
+```
+
+To run the full TCK against Payara Server using remote Arquillian container, activate the `payara-server-remote` profile and specify `payara.home`:
+
+```
+mvn clean verify -Dpayara.version=xyz -Dpayara.home=/path/to/payara6 -Ppayara-server-remote
+```
+
+If you wish to skip the test setup (for example if re-running against a remote server), add the `-Dskip.setup` property:
+
+```
+mvn clean verify -Dpayara.version=xyz -Dpayara.home=/path/to/payara6 -Dskip.setup -Ppayara-server-remote
+```
+
+## Details
+
+This module is composed of 2 modules, which are executed from the root module:
+
+* apitests - executes API behavior tests against a running Payara server
+* sigtest - executes API signature tests against Payara classes

--- a/batch-tck/apitests/pom.xml
+++ b/batch-tck/apitests/pom.xml
@@ -34,7 +34,8 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
     <properties>
         <derby.version>10.15.2.0</derby.version>
         <derby.zip.url>https://dlcdn.apache.org//db/derby/db-derby-${derby.version}/db-derby-${derby.version}-bin.zip</derby.zip.url>
-        <db.home>${project.build.directory}${file.separator}db-derby-${derby.version}-bin</db.home>
+        <db.download.location>${project.build.directory}${file.separator}db-derby-${derby.version}-bin</db.download.location>
+        <payara.db.home>${payara.home}${file.separator}javadb</payara.db.home>
 
         <!-- Used to help determine sh vs. bat -->
         <script.ext/>
@@ -160,8 +161,8 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                         <configuration>
                             <skip>${skipITs}</skip>
                             <target>
-                                <copy file="${project.basedir}/src/test/resources/arquillian.xml"
-                                      todir="${project.build.directory}/test-classes"
+                                <copy file="${project.basedir}${file.separator}src${file.separator}test${file.separator}resources${file.separator}arquillian.xml"
+                                      todir="${project.build.directory}${file.separator}test-classes"
                                       overwrite="true"/>
                             </target>
                         </configuration>
@@ -170,15 +171,18 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                     <execution>
                         <id>copy-derby-to-payara</id>
                         <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
                         <configuration>
                             <skip>${skipITs}</skip>
                             <target unless="skip.setup">
-                                <move todir="${payara.home}/javadb">
-                                    <fileset dir="${db.home}" />
+                                <move todir="${payara.db.home}">
+                                    <fileset dir="${db.download.location}" />
                                 </move>
-                                <copy file="${payara.home}/javadb/lib/derbytools.jar" todir="${payara.home}/glassfish/domains/domain1/lib"/>
-                                <copy file="${payara.home}/javadb/lib/derbyclient.jar" todir="${payara.home}/glassfish/domains/domain1/lib"/>
-                                <copy file="${payara.home}/javadb/lib/derbyshared.jar" todir="${payara.home}/glassfish/domains/domain1/lib"/>
+                                <copy file="${payara.db.home}${file.separator}lib${file.separator}derbytools.jar" todir="${payara.home}${file.separator}glassfish${file.separator}domains${file.separator}domain1${file.separator}lib"/>
+                                <copy file="${payara.db.home}${file.separator}lib${file.separator}derbyclient.jar" todir="${payara.home}${file.separator}glassfish${file.separator}domains${file.separator}domain1${file.separator}lib"/>
+                                <copy file="${payara.db.home}${file.separator}lib${file.separator}derbyshared.jar" todir="${payara.home}${file.separator}glassfish${file.separator}domains${file.separator}domain1${file.separator}lib"/>
                             </target>
                         </configuration>
                     </execution>
@@ -208,7 +212,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                         <configuration>
                             <skip>${skipITs}</skip>
                             <target>
-                                <exec executable="${db.home}/bin/startNetworkServer${script.ext}" spawn="true"/>
+                                <exec executable="${payara.db.home}${file.separator}bin${file.separator}startNetworkServer${script.ext}" spawn="true"/>
                             </target>
                         </configuration>
                     </execution>
@@ -222,8 +226,8 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                         <configuration>
                             <skip>${skipITs}</skip>
                             <target>
-                                <exec executable="${db.home}/bin/ij${script.ext}">
-                                    <arg value="${basedir}/src/test/resources/derby.ddl.jbatch-tck.sql" />
+                                <exec executable="${payara.db.home}${file.separator}bin/ij${script.ext}">
+                                    <arg value="${basedir}${file.separator}src${file.separator}test${file.separator}resources${file.separator}derby.ddl.jbatch-tck.sql" />
                                 </exec>
                             </target>
                         </configuration>
@@ -307,7 +311,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                         <configuration>
                             <skip>${skipITs}</skip>
                             <target>
-                                <exec executable="${db.home}/bin/stopNetworkServer${script.ext}"/>
+                                <exec executable="${payara.db.home}${file.separator}bin${file.separator}stopNetworkServer${script.ext}"/>
                             </target>
                         </configuration>
                     </execution>
@@ -330,8 +334,8 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                                 <artifactItem>
                                     <groupId>jakarta.batch</groupId>
                                     <artifactId>com.ibm.jbatch.tck</artifactId>
-                                    <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
-                                    <includes>testprofiles/*,ddls/*,test-summary-stylesheet.xsl</includes>
+                                    <outputDirectory>${project.build.directory}${file.separator}test-classes</outputDirectory>
+                                    <includes>testprofiles${file.separator}*,ddls${file.separator}*,test-summary-stylesheet.xsl</includes>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>
@@ -363,7 +367,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                             <dependenciesToScan>
                                 <dependency>jakarta.batch:com.ibm.jbatch.tck</dependency>
                             </dependenciesToScan>
-                            <includesFile>${project.build.directory}/test-classes/testprofiles/batch-tck-impl-EE-platform-core-suite-includes.txt</includesFile>
+                            <includesFile>${project.build.directory}${file.separator}test-classes${file.separator}testprofiles${file.separator}batch-tck-impl-EE-platform-core-suite-includes.txt</includesFile>
                             <reportNameSuffix>ee-core-suite</reportNameSuffix>
                             <systemPropertyVariables>
                                 <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
@@ -380,7 +384,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                             <dependenciesToScan>
                                 <dependency>jakarta.batch:com.ibm.jbatch.tck.appbean</dependency>
                             </dependenciesToScan>
-                            <includesFile>${project.build.directory}/test-classes/testprofiles/batch-tck-impl-appjoboperator-suite-includes.txt</includesFile>
+                            <includesFile>${project.build.directory}${file.separator}test-classes${file.separator}testprofiles${file.separator}batch-tck-impl-appjoboperator-suite-includes.txt</includesFile>
                             <reportNameSuffix>appjoboperator</reportNameSuffix>
                             <systemPropertyVariables>
                                 <jakarta.batch.tck.vehicles.vehicleName>appjoboperator</jakarta.batch.tck.vehicles.vehicleName>

--- a/batch-tck/apitests/pom.xml
+++ b/batch-tck/apitests/pom.xml
@@ -226,7 +226,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                         <configuration>
                             <skip>${skipITs}</skip>
                             <target>
-                                <exec executable="${payara.db.home}${file.separator}bin/ij${script.ext}">
+                                <exec executable="${payara.db.home}${file.separator}bin${file.separator}ij${script.ext}">
                                     <arg value="${basedir}${file.separator}src${file.separator}test${file.separator}resources${file.separator}derby.ddl.jbatch-tck.sql" />
                                 </exec>
                             </target>

--- a/batch-tck/apitests/pom.xml
+++ b/batch-tck/apitests/pom.xml
@@ -44,6 +44,8 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
         <maven.antrun.plugin.version>3.1.0</maven.antrun.plugin.version>
         <maven.dependency.plugin.version>3.3.0</maven.dependency.plugin.version>
         <maven.failsafe.plugin.version>3.0.0-M7</maven.failsafe.plugin.version>
+
+        <slf4j.version>1.7.30</slf4j.version>
     </properties>
 
     <dependencies>
@@ -91,6 +93,11 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
             <artifactId>jakarta.batch.reporting</artifactId>
             <scope>test</scope>
             <version>${jakarta.batch.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>${slf4j.version}</version>
         </dependency>
 
         <!-- Payara-specific Batch TCK Dependencies -->

--- a/batch-tck/apitests/pom.xml
+++ b/batch-tck/apitests/pom.xml
@@ -418,12 +418,6 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                     </execution>
                 </executions>
             </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-
-            </plugin>
         </plugins>
     </build>
 

--- a/batch-tck/apitests/pom.xml
+++ b/batch-tck/apitests/pom.xml
@@ -212,7 +212,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                         <configuration>
                             <skip>${skipITs}</skip>
                             <target>
-                                <exec executable="${payara.db.home}${file.separator}bin${file.separator}startNetworkServer${script.ext}" spawn="true"/>
+                                <exec executable="${payara.db.home}${file.separator}bin${file.separator}startNetworkServer${script.ext}" spawn="true" dir="${payara.db.home}"/>
                                 <echo message="Waiting 3 seconds for database in forked process to start..."/>
                                 <sleep seconds="3"/>
                             </target>
@@ -228,7 +228,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                         <configuration>
                             <skip>${skipITs}</skip>
                             <target>
-                                <exec executable="${payara.db.home}${file.separator}bin${file.separator}ij${script.ext}">
+                                <exec executable="${payara.db.home}${file.separator}bin${file.separator}ij${script.ext}" dir="${payara.db.home}">
                                     <arg value="${basedir}${file.separator}src${file.separator}test${file.separator}resources${file.separator}derby.ddl.jbatch-tck.sql" />
                                 </exec>
                             </target>
@@ -313,7 +313,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                         <configuration>
                             <skip>${skipITs}</skip>
                             <target>
-                                <exec executable="${payara.db.home}${file.separator}bin${file.separator}stopNetworkServer${script.ext}"/>
+                                <exec executable="${payara.db.home}${file.separator}bin${file.separator}stopNetworkServer${script.ext}" dir="${payara.db.home}"/>
                             </target>
                         </configuration>
                     </execution>

--- a/batch-tck/apitests/pom.xml
+++ b/batch-tck/apitests/pom.xml
@@ -24,7 +24,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
     <parent>
         <groupId>fish.payara.jakarta.tests.tck</groupId>
         <artifactId>batch-tck</artifactId>
-        <version>2.1.1</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>batch-tck-api-tests</artifactId>
@@ -51,15 +51,18 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
             <groupId>jakarta.batch</groupId>
             <artifactId>com.ibm.jbatch.tck</artifactId>
             <scope>test</scope>
+            <version>${jakarta.batch.tck.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.batch</groupId>
             <artifactId>com.ibm.jbatch.tck.spi</artifactId>
             <scope>test</scope>
+            <version>${jakarta.batch.tck.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.batch</groupId>
             <artifactId>jakarta.batch.arquillian.extension</artifactId>
+            <version>${jakarta.batch.tck.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
@@ -79,11 +82,12 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
             <groupId>jakarta.batch</groupId>
             <artifactId>jakarta.batch.reporting</artifactId>
             <scope>test</scope>
+            <version>${jakarta.batch.tck.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.slf4j</groupId>-->
+<!--            <artifactId>slf4j-jdk14</artifactId>-->
+<!--        </dependency>-->
 
         <!-- Payara-specific Batch TCK Dependencies -->
         <dependency>
@@ -117,7 +121,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                 <executions>
                     <execution>
                         <id>download-derby</id>
-                        <phase>generate-resources</phase>
+                        <phase>generate-test-resources</phase>
                         <goals>
                             <goal>wget</goal>
                         </goals>
@@ -193,8 +197,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                         <configuration>
                             <skip>${skipITs}</skip>
                             <target>
-                                <exec executable="${db.home}/bin/startNetworkServer${script.ext}">
-                                </exec>
+                                <exec executable="${db.home}/bin/startNetworkServer${script.ext}" spawn="true"/>
                             </target>
                         </configuration>
                     </execution>
@@ -293,8 +296,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                         <configuration>
                             <skip>${skipITs}</skip>
                             <target>
-                                <exec executable="${db.home}/bin/stopNetworkServer${script.ext}">
-                                </exec>
+                                <exec executable="${db.home}/bin/stopNetworkServer${script.ext}"/>
                             </target>
                         </configuration>
                     </execution>
@@ -346,7 +348,9 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
         <profile>
             <id>payara-server-managed</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>!payara.server.remote</name>
+                </property>
             </activation>
 
             <properties>
@@ -370,12 +374,12 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                         <executions>
                             <execution>
                                 <id>unpack-payara</id>
-                                <phase>pre-integration-test</phase>
+                                <phase>generate-test-resources</phase>
                                 <goals>
                                     <goal>unpack</goal>
                                 </goals>
                                 <configuration>
-                                    <skip>${skipITs}</skip>
+                                    <skip>!${payara.server.remote}</skip>
                                     <artifactItems>
                                         <artifactItem>
                                             <groupId>fish.payara.distributions</groupId>

--- a/batch-tck/apitests/pom.xml
+++ b/batch-tck/apitests/pom.xml
@@ -1,0 +1,397 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+Copyright (c) 2022 Contributors to the Eclipse Foundation
+
+  See the NOTICE file distributed with this work for additional information
+  regarding copyright ownership. Licensed under the Apache License,
+  Version 2.0 (the "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>fish.payara.jakarta.tests.tck</groupId>
+        <artifactId>batch-tck</artifactId>
+        <version>2.1.1</version>
+    </parent>
+
+    <artifactId>batch-tck-api-tests</artifactId>
+    <packaging>pom</packaging>
+    <name>Jakarta Batch API TCK Runner for Payara</name>
+
+    <properties>
+        <derby.version>10.15.2.0</derby.version>
+        <derby.zip.url>https://dlcdn.apache.org//db/derby/db-derby-${derby.version}/db-derby-${derby.version}-bin.zip</derby.zip.url>
+        <db.home>${project.build.directory}${file.separator}db-derby-${derby.version}-bin</db.home>
+
+        <!-- Used to help determine sh vs. bat -->
+        <script.ext/>
+        <payara.executable>${payara.home}${file.separator}glassfish${file.separator}bin${file.separator}asadmin${script.ext}</payara.executable>
+
+        <download.maven.plugin.version>1.6.8</download.maven.plugin.version>
+        <maven.antrun.plugin.version>3.1.0</maven.antrun.plugin.version>
+    </properties>
+
+    <dependencies>
+
+        <!-- Common Batch TCK dependencies -->
+        <dependency>
+            <groupId>jakarta.batch</groupId>
+            <artifactId>com.ibm.jbatch.tck</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.batch</groupId>
+            <artifactId>com.ibm.jbatch.tck.spi</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.batch</groupId>
+            <artifactId>jakarta.batch.arquillian.extension</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-test-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.batch</groupId>
+            <artifactId>jakarta.batch.reporting</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+        </dependency>
+
+        <!-- Payara-specific Batch TCK Dependencies -->
+        <dependency>
+            <groupId>org.glassfish.hk2</groupId>
+            <artifactId>hk2-locator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-multipart</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <artifactId>download-maven-plugin</artifactId>
+                <version>${download.maven.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>download-derby</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipITs}</skip>
+                            <url>${derby.zip.url}</url>
+                            <unpack>true</unpack>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>${maven.antrun.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>copy-arquillian-config-to-cp</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipITs}</skip>
+                            <target>
+                                <copy file="${project.basedir}/src/test/resources/arquillian.xml"
+                                      todir="${project.build.directory}/test-classes"
+                                      overwrite="true"/>
+                            </target>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>copy-derby-to-payara</id>
+                        <phase>pre-integration-test</phase>
+                        <configuration>
+                            <skip>${skipITs}</skip>
+                            <target unless="skip.setup">
+                                <move todir="${payara.home}/javadb">
+                                    <fileset dir="${db.home}" />
+                                </move>
+                                <copy file="${payara.home}/javadb/lib/derbytools.jar" todir="${payara.home}/glassfish/domains/domain1/lib"/>
+                                <copy file="${payara.home}/javadb/lib/derbyclient.jar" todir="${payara.home}/glassfish/domains/domain1/lib"/>
+                                <copy file="${payara.home}/javadb/lib/derbyshared.jar" todir="${payara.home}/glassfish/domains/domain1/lib"/>
+                            </target>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>start-managed-payara-server-for-test-setup</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipITs}</skip>
+                            <target if="payara.server.managed" unless="skip.setup">
+                                <exec executable="${payara.executable}">
+                                    <arg value="start-domain" />
+                                </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>start-database</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipITs}</skip>
+                            <target>
+                                <exec executable="${db.home}/bin/startNetworkServer${script.ext}">
+                                </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>execute-ddl</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipITs}</skip>
+                            <target>
+                                <exec executable="${db.home}/bin/ij${script.ext}">
+                                    <arg value="${basedir}/src/test/resources/derby.ddl.jbatch-tck.sql" />
+                                </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>create-jdbc-connection-pool</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipITs}</skip>
+                            <target unless="skip.setup">
+                                <exec executable="${payara.executable}">
+                                    <arg value="create-jdbc-connection-pool" />
+                                    <arg value="--datasourceClassname=org.apache.derby.jdbc.ClientDataSource40" />
+                                    <arg value="--resType=javax.sql.DataSource" />
+                                    <arg value="--property=DatabaseName=batch:serverName=localhost:PortNumber=1527:User=batch:Password=batch" />
+                                    <arg value="batchtck" />
+                                </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>create-jdbc-resource</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipITs}</skip>
+                            <target unless="skip.setup">
+                                <exec executable="${payara.executable}">
+                                    <arg value="create-jdbc-resource" />
+                                    <arg value="--poolName=batchtck" />
+                                    <arg value="jdbc/orderDB" />
+                                </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>stop-managed-payara-server-post-test-setup</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipITs}</skip>
+                            <target if="payara.server.managed" unless="skip.setup">
+                                <exec executable="${payara.executable}">
+                                    <arg value="stop-domain" />
+                                </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>restart-remote-payara-server-post-test-setup</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipITs}</skip>
+                            <target if="payara.server.remote" unless="skip.setup">
+                                <exec executable="${payara.executable}">
+                                    <arg value="restart-domain" />
+                                </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>stop-database</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipITs}</skip>
+                            <target>
+                                <exec executable="${db.home}/bin/stopNetworkServer${script.ext}">
+                                </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <arquillian.launch>payara</arquillian.launch>
+                        <arquillian.extensions.jakarta.batch.groupPrefixesToIgnore>org.glassfish</arquillian.extensions.jakarta.batch.groupPrefixesToIgnore>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <properties>
+                <script.ext>.bat</script.ext>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>payara-server-remote</id>
+
+            <properties>
+                <payara.server.remote/>
+            </properties>
+
+            <dependencies>
+                <dependency>
+                    <groupId>fish.payara.arquillian</groupId>
+                    <artifactId>arquillian-payara-server-remote</artifactId>
+                    <version>${payara.arquillian.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>payara-server-managed</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+
+            <properties>
+                <payara.server.managed/>
+            </properties>
+
+            <dependencies>
+                <dependency>
+                    <groupId>fish.payara.arquillian</groupId>
+                    <artifactId>arquillian-payara-server-managed</artifactId>
+                    <version>${payara.arquillian.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack-payara</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${skipITs}</skip>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>fish.payara.distributions</groupId>
+                                            <artifactId>payara</artifactId>
+                                            <version>${payara.version}</version>
+                                            <type>zip</type>
+                                            <overWrite>false</overWrite>
+                                            <outputDirectory>${project.build.directory}</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/batch-tck/apitests/pom.xml
+++ b/batch-tck/apitests/pom.xml
@@ -51,18 +51,18 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
             <groupId>jakarta.batch</groupId>
             <artifactId>com.ibm.jbatch.tck</artifactId>
             <scope>test</scope>
-            <version>${jakarta.batch.tck.version}</version>
+            <version>${jakarta.batch.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.batch</groupId>
             <artifactId>com.ibm.jbatch.tck.spi</artifactId>
             <scope>test</scope>
-            <version>${jakarta.batch.tck.version}</version>
+            <version>${jakarta.batch.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.batch</groupId>
             <artifactId>jakarta.batch.arquillian.extension</artifactId>
-            <version>${jakarta.batch.tck.version}</version>
+            <version>${jakarta.batch.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
@@ -82,12 +82,8 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
             <groupId>jakarta.batch</groupId>
             <artifactId>jakarta.batch.reporting</artifactId>
             <scope>test</scope>
-            <version>${jakarta.batch.tck.version}</version>
+            <version>${jakarta.batch.version}</version>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>org.slf4j</groupId>-->
-<!--            <artifactId>slf4j-jdk14</artifactId>-->
-<!--        </dependency>-->
 
         <!-- Payara-specific Batch TCK Dependencies -->
         <dependency>
@@ -305,13 +301,125 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-tck</id>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <phase>pre-integration-test</phase>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>jakarta.batch</groupId>
+                                    <artifactId>com.ibm.jbatch.tck</artifactId>
+                                    <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
+                                    <includes>testprofiles/*,ddls/*,test-summary-stylesheet.xsl</includes>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
+
                 <configuration>
+                    <failIfNoTests>false</failIfNoTests>
+                    <systemPropertiesFile>${project.basedir}/test.properties</systemPropertiesFile>
                     <systemPropertyVariables>
+                        <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
                         <arquillian.launch>payara</arquillian.launch>
                         <arquillian.extensions.jakarta.batch.groupPrefixesToIgnore>org.glassfish</arquillian.extensions.jakarta.batch.groupPrefixesToIgnore>
                     </systemPropertyVariables>
                 </configuration>
+
+                <executions>
+                    <execution>
+                        <id>core-ejb</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                        <configuration>
+                            <classpathDependencyExcludes>jakarta.batch:com.ibm.jbatch.tck.appbean</classpathDependencyExcludes>
+                            <dependenciesToScan>
+                                <dependency>jakarta.batch:com.ibm.jbatch.tck</dependency>
+                            </dependenciesToScan>
+                            <includesFile>${project.build.directory}/test-classes/testprofiles/batch-tck-impl-EE-platform-core-suite-includes.txt</includesFile>
+                            <reportNameSuffix>core-ejb</reportNameSuffix>
+                            <systemPropertyVariables>
+                                <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
+                                <jakarta.batch.tck.vehicles.vehicleName>ejb</jakarta.batch.tck.vehicles.vehicleName>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>core-web</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                        <configuration>
+                            <classpathDependencyExcludes>jakarta.batch:com.ibm.jbatch.tck.appbean</classpathDependencyExcludes>
+                            <dependenciesToScan>
+                                <dependency>jakarta.batch:com.ibm.jbatch.tck</dependency>
+                            </dependenciesToScan>
+                            <includesFile>${project.build.directory}/test-classes/testprofiles/batch-tck-impl-EE-platform-core-suite-includes.txt</includesFile>
+                            <reportNameSuffix>core-web</reportNameSuffix>
+                            <systemPropertyVariables>
+                                <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
+                                <jakarta.batch.tck.vehicles.vehicleName>web</jakarta.batch.tck.vehicles.vehicleName>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>appbean-ejb</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                        <configuration>
+                            <dependenciesToScan>
+                                <dependency>jakarta.batch:com.ibm.jbatch.tck.appbean</dependency>
+                            </dependenciesToScan>
+                            <includesFile>${project.build.directory}/test-classes/testprofiles/batch-tck-impl-appjoboperator-suite-includes.txt</includesFile>
+                            <reportNameSuffix>appbean-ejb</reportNameSuffix>
+                            <systemPropertyVariables>
+                                <jakarta.batch.tck.vehicles.vehicleName>ejb</jakarta.batch.tck.vehicles.vehicleName>
+                                <arquillian.extensions.jakarta.batch.appbean>true</arquillian.extensions.jakarta.batch.appbean>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>appbean-web</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                        <configuration>
+                            <dependenciesToScan>
+                                <dependency>jakarta.batch:com.ibm.jbatch.tck.appbean</dependency>
+                            </dependenciesToScan>
+                            <includesFile>${project.build.directory}/test-classes/testprofiles/batch-tck-impl-appjoboperator-suite-includes.txt</includesFile>
+                            <reportNameSuffix>appbean-web</reportNameSuffix>
+                            <systemPropertyVariables>
+                                <jakarta.batch.tck.vehicles.vehicleName>web</jakarta.batch.tck.vehicles.vehicleName>
+                                <arquillian.extensions.jakarta.batch.appbean>true</arquillian.extensions.jakarta.batch.appbean>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>verify</id>
+                        <goals>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+
             </plugin>
         </plugins>
     </build>

--- a/batch-tck/apitests/pom.xml
+++ b/batch-tck/apitests/pom.xml
@@ -213,6 +213,8 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                             <skip>${skipITs}</skip>
                             <target>
                                 <exec executable="${payara.db.home}${file.separator}bin${file.separator}startNetworkServer${script.ext}" spawn="true"/>
+                                <echo message="Waiting 3 seconds for database in forked process to start..."/>
+                                <sleep seconds="3"/>
                             </target>
                         </configuration>
                     </execution>

--- a/batch-tck/apitests/pom.xml
+++ b/batch-tck/apitests/pom.xml
@@ -57,6 +57,12 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
         </dependency>
         <dependency>
             <groupId>jakarta.batch</groupId>
+            <artifactId>com.ibm.jbatch.tck.appbean</artifactId>
+            <scope>test</scope>
+            <version>${jakarta.batch.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.batch</groupId>
             <artifactId>com.ibm.jbatch.tck.spi</artifactId>
             <scope>test</scope>
             <version>${jakarta.batch.version}</version>
@@ -341,7 +347,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
 
                 <executions>
                     <execution>
-                        <id>core-ejb</id>
+                        <id>ee-core-suite</id>
                         <goals>
                             <goal>integration-test</goal>
                         </goals>
@@ -351,33 +357,15 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                                 <dependency>jakarta.batch:com.ibm.jbatch.tck</dependency>
                             </dependenciesToScan>
                             <includesFile>${project.build.directory}/test-classes/testprofiles/batch-tck-impl-EE-platform-core-suite-includes.txt</includesFile>
-                            <reportNameSuffix>core-ejb</reportNameSuffix>
+                            <reportNameSuffix>ee-core-suite</reportNameSuffix>
                             <systemPropertyVariables>
                                 <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
-                                <jakarta.batch.tck.vehicles.vehicleName>ejb</jakarta.batch.tck.vehicles.vehicleName>
+                                <jakarta.batch.tck.vehicles.vehicleName>ee-core-suite</jakarta.batch.tck.vehicles.vehicleName>
                             </systemPropertyVariables>
                         </configuration>
                     </execution>
                     <execution>
-                        <id>core-web</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                        </goals>
-                        <configuration>
-                            <classpathDependencyExcludes>jakarta.batch:com.ibm.jbatch.tck.appbean</classpathDependencyExcludes>
-                            <dependenciesToScan>
-                                <dependency>jakarta.batch:com.ibm.jbatch.tck</dependency>
-                            </dependenciesToScan>
-                            <includesFile>${project.build.directory}/test-classes/testprofiles/batch-tck-impl-EE-platform-core-suite-includes.txt</includesFile>
-                            <reportNameSuffix>core-web</reportNameSuffix>
-                            <systemPropertyVariables>
-                                <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
-                                <jakarta.batch.tck.vehicles.vehicleName>web</jakarta.batch.tck.vehicles.vehicleName>
-                            </systemPropertyVariables>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>appbean-ejb</id>
+                        <id>appjoboperator-suite</id>
                         <goals>
                             <goal>integration-test</goal>
                         </goals>
@@ -386,35 +374,12 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                                 <dependency>jakarta.batch:com.ibm.jbatch.tck.appbean</dependency>
                             </dependenciesToScan>
                             <includesFile>${project.build.directory}/test-classes/testprofiles/batch-tck-impl-appjoboperator-suite-includes.txt</includesFile>
-                            <reportNameSuffix>appbean-ejb</reportNameSuffix>
+                            <reportNameSuffix>appjoboperator</reportNameSuffix>
                             <systemPropertyVariables>
-                                <jakarta.batch.tck.vehicles.vehicleName>ejb</jakarta.batch.tck.vehicles.vehicleName>
+                                <jakarta.batch.tck.vehicles.vehicleName>appjoboperator</jakarta.batch.tck.vehicles.vehicleName>
                                 <arquillian.extensions.jakarta.batch.appbean>true</arquillian.extensions.jakarta.batch.appbean>
                             </systemPropertyVariables>
                         </configuration>
-                    </execution>
-                    <execution>
-                        <id>appbean-web</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                        </goals>
-                        <configuration>
-                            <dependenciesToScan>
-                                <dependency>jakarta.batch:com.ibm.jbatch.tck.appbean</dependency>
-                            </dependenciesToScan>
-                            <includesFile>${project.build.directory}/test-classes/testprofiles/batch-tck-impl-appjoboperator-suite-includes.txt</includesFile>
-                            <reportNameSuffix>appbean-web</reportNameSuffix>
-                            <systemPropertyVariables>
-                                <jakarta.batch.tck.vehicles.vehicleName>web</jakarta.batch.tck.vehicles.vehicleName>
-                                <arquillian.extensions.jakarta.batch.appbean>true</arquillian.extensions.jakarta.batch.appbean>
-                            </systemPropertyVariables>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>verify</id>
-                        <goals>
-                            <goal>verify</goal>
-                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/batch-tck/apitests/pom.xml
+++ b/batch-tck/apitests/pom.xml
@@ -43,6 +43,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
         <download.maven.plugin.version>1.6.8</download.maven.plugin.version>
         <maven.antrun.plugin.version>3.1.0</maven.antrun.plugin.version>
         <maven.dependency.plugin.version>3.3.0</maven.dependency.plugin.version>
+        <maven.failsafe.plugin.version>3.0.0-M7</maven.failsafe.plugin.version>
     </properties>
 
     <dependencies>
@@ -327,7 +328,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-
+                <version>${maven.failsafe.plugin.version}</version>
                 <configuration>
                     <failIfNoTests>false</failIfNoTests>
                     <systemPropertyVariables>

--- a/batch-tck/apitests/pom.xml
+++ b/batch-tck/apitests/pom.xml
@@ -42,6 +42,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
 
         <download.maven.plugin.version>1.6.8</download.maven.plugin.version>
         <maven.antrun.plugin.version>3.1.0</maven.antrun.plugin.version>
+        <maven.dependency.plugin.version>3.3.0</maven.dependency.plugin.version>
     </properties>
 
     <dependencies>
@@ -302,6 +303,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
+                <version>${maven.dependency.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>unpack-tck</id>

--- a/batch-tck/apitests/pom.xml
+++ b/batch-tck/apitests/pom.xml
@@ -137,7 +137,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                 <version>${maven.antrun.plugin.version}</version>
                 <executions>
                     <execution>
-                        <id>copy-arquillian-config-to-cp</id>
+                        <id>copy-arquillian-config</id>
                         <phase>generate-test-resources</phase>
                         <goals>
                             <goal>run</goal>
@@ -328,11 +328,11 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
 
                 <configuration>
                     <failIfNoTests>false</failIfNoTests>
-                    <systemPropertiesFile>${project.basedir}/test.properties</systemPropertiesFile>
                     <systemPropertyVariables>
                         <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
                         <arquillian.launch>payara</arquillian.launch>
                         <arquillian.extensions.jakarta.batch.groupPrefixesToIgnore>org.glassfish</arquillian.extensions.jakarta.batch.groupPrefixesToIgnore>
+                        <payara.home>${payara.home}</payara.home>
                     </systemPropertyVariables>
                 </configuration>
 
@@ -487,7 +487,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                                     <goal>unpack</goal>
                                 </goals>
                                 <configuration>
-                                    <skip>!${payara.server.remote}</skip>
+                                    <skip>!${skipITs}</skip>
                                     <artifactItems>
                                         <artifactItem>
                                             <groupId>fish.payara.distributions</groupId>

--- a/batch-tck/apitests/pom.xml
+++ b/batch-tck/apitests/pom.xml
@@ -41,11 +41,6 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
         <script.ext/>
         <payara.executable>${payara.home}${file.separator}glassfish${file.separator}bin${file.separator}asadmin${script.ext}</payara.executable>
 
-        <download.maven.plugin.version>1.6.8</download.maven.plugin.version>
-        <maven.antrun.plugin.version>3.1.0</maven.antrun.plugin.version>
-        <maven.dependency.plugin.version>3.3.0</maven.dependency.plugin.version>
-        <maven.failsafe.plugin.version>3.0.0-M7</maven.failsafe.plugin.version>
-
         <slf4j.version>1.7.30</slf4j.version>
     </properties>
 

--- a/batch-tck/apitests/src/test/resources/arquillian.xml
+++ b/batch-tck/apitests/src/test/resources/arquillian.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<!-- 
+Copyright (c) 2021-2022 Contributors to the Eclipse Foundation
+
+See the NOTICE file distributed with this work for additional information regarding copyright 
+ownership. Licensed under the Apache License, Version 2.0 (the "License"); 
+you may not use this file except in compliance with the License. You may 
+obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+Unless required by applicable law or agreed to in writing, software distributed 
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
+OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
+the specific language governing permissions and limitations under the License. 
+SPDX-License-Identifier: Apache-2.0 -->
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://jboss.org/schema/arquillian"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <container qualifier="payara">
+        <configuration>
+            <property name="adminHost">localhost</property>
+            <property name="adminHttps">false</property>
+            <property name="authorisation">false</property>
+            <property name="adminPort">4848</property>
+        </configuration>
+    </container>
+
+</arquillian>

--- a/batch-tck/apitests/src/test/resources/derby.ddl.jbatch-tck.sql
+++ b/batch-tck/apitests/src/test/resources/derby.ddl.jbatch-tck.sql
@@ -1,0 +1,87 @@
+CONNECT 'jdbc:derby://localhost:1527/batch;create=true';
+
+DROP TABLE Numbers;
+DROP TABLE Orders;
+DROP TABLE Inventory;
+
+CREATE TABLE Numbers
+(
+    item     INT,
+    quantity INT
+);
+
+CREATE TABLE Orders
+(
+    orderID  INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1) PRIMARY KEY,
+    itemID   INT,
+    quantity INT
+);
+
+CREATE TABLE Inventory
+(
+    itemID   INT NOT NULL PRIMARY KEY,
+    quantity INT NOT NULL
+);
+
+INSERT INTO Inventory
+VALUES (1, 100);
+
+INSERT INTO Numbers
+VALUES (1, 10);
+
+INSERT INTO Numbers
+VALUES (2, 10);
+
+INSERT INTO Numbers
+VALUES (3, 10);
+
+INSERT INTO Numbers
+VALUES (4, 10);
+
+INSERT INTO Numbers
+VALUES (5, 10);
+
+INSERT INTO Numbers
+VALUES (6, 10);
+
+INSERT INTO Numbers
+VALUES (7, 10);
+
+INSERT INTO Numbers
+VALUES (8, 10);
+
+INSERT INTO Numbers
+VALUES (9, 10);
+
+INSERT INTO Numbers
+VALUES (10, 10);
+
+INSERT INTO Numbers
+VALUES (11, 10);
+
+INSERT INTO Numbers
+VALUES (12, 10);
+
+INSERT INTO Numbers
+VALUES (13, 10);
+
+INSERT INTO Numbers
+VALUES (14, 10);
+
+INSERT INTO Numbers
+VALUES (15, 10);
+
+INSERT INTO Numbers
+VALUES (16, 10);
+
+INSERT INTO Numbers
+VALUES (17, 10);
+
+INSERT INTO Numbers
+VALUES (18, 10);
+
+INSERT INTO Numbers
+VALUES (19, 10);
+
+INSERT INTO Numbers
+VALUES (20, 10);

--- a/batch-tck/pom.xml
+++ b/batch-tck/pom.xml
@@ -21,21 +21,17 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>jakarta.batch</groupId>
-        <artifactId>jakarta.batch.arquillian.exec-parent</artifactId>
-        <version>2.1.1</version>
-        <relativePath></relativePath>
-    </parent>
 
     <groupId>fish.payara.jakarta.tests.tck</groupId>
     <artifactId>batch-tck</artifactId>
+    <version>1.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <name>Jakarta Batch TCK Runner for Payara</name>
 
     <properties>
-        <jakarta.batch.version>2.1.0</jakarta.batch.version>
+        <jakarta.batch.api.version>2.1.0</jakarta.batch.api.version>
+        <jakarta.batch.tck.version>2.1.1</jakarta.batch.tck.version>
 
         <payara.version>6.2022.1.Alpha5-SNAPSHOT</payara.version>
         <payara.home>${project.build.directory}${file.separator}payara6</payara.home>

--- a/batch-tck/pom.xml
+++ b/batch-tck/pom.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+  Copyright (c) 2022 Contributors to the Eclipse Foundation
+
+  See the NOTICE file distributed with this work for additional information
+  regarding copyright ownership. Licensed under the Apache License,
+  Version 2.0 (the "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>jakarta.batch</groupId>
+        <artifactId>jakarta.batch.arquillian.exec-parent</artifactId>
+        <version>2.1.1</version>
+        <relativePath></relativePath>
+    </parent>
+
+    <groupId>fish.payara.jakarta.tests.tck</groupId>
+    <artifactId>batch-tck</artifactId>
+
+    <packaging>pom</packaging>
+    <name>Jakarta Batch TCK Runner for Payara</name>
+
+    <properties>
+        <jakarta.batch.version>2.1.0</jakarta.batch.version>
+
+        <payara.version>6.2022.1.Alpha5-SNAPSHOT</payara.version>
+        <payara.home>${project.build.directory}${file.separator}payara6</payara.home>
+
+        <payara.arquillian.version>3.0.alpha6</payara.arquillian.version>
+        <arquillian.version>1.7.0.Alpha10</arquillian.version>
+        <junit.version>5.9.0</junit.version>
+    </properties>
+
+    <modules>
+        <module>sigtests</module>
+        <module>apitests</module>
+    </modules>
+
+    <repositories>
+        <repository>
+            <id>jakarta-snapshots</id>
+            <url>https://jakarta.oss.sonatype.org/content/repositories/staging/</url>
+        </repository>
+        <repository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2</url>
+        </repository>
+        <repository>
+            <id>jboss</id>
+            <url>https://repository.jboss.org/nexus/content/repositories/releases/</url>
+        </repository>
+
+        <!-- Payara Community Repos -->
+        <repository>
+            <id>payara-nexus-artifacts</id>
+            <url>https://nexus.payara.fish/repository/payara-artifacts</url>
+        </repository>
+        <repository>
+            <id>payara-nexus-snapshots</id>
+            <url>https://nexus.payara.fish/repository/payara-snapshots</url>
+        </repository>
+
+        <!-- Payara Enterprise Repos -->
+        <repository>
+            <id>payara-nexus-enterprise-distributions</id>
+            <url>https://nexus.payara.fish/repository/payara-enterprise</url>
+        </repository>
+        <repository>
+            <id>payara-nexus-enterprise-artifacts</id>
+            <url>https://nexus.payara.fish/repository/payara-enterprise-artifacts-private</url>
+        </repository>
+        <repository>
+            <id>payara-nexus-enterprise-snapshots</id>
+            <url>https://nexus.payara.fish/repository/payara-enterprise-snapshots-private</url>
+        </repository>
+
+        <!-- Payara Release Staging Repo -->
+        <repository>
+            <id>payara-nexus-staging</id>
+            <url>https://nexus.payara.fish/repository/payara-staging</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>payara-nexus-artifacts</id>
+            <url>https://nexus.payara.fish/repository/payara-artifacts</url>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>fish.payara.api</groupId>
+                <artifactId>payara-bom</artifactId>
+                <version>${payara.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>${arquillian.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/batch-tck/pom.xml
+++ b/batch-tck/pom.xml
@@ -32,7 +32,8 @@
     <properties>
         <jakarta.batch.version>2.1.1</jakarta.batch.version>
 
-        <payara.version>6.2022.1.Alpha5-SNAPSHOT</payara.version>
+        <!-- Note that Shrinkwrap Maven resolver WILL NOT read in whatever you specify on the command line - it will ALWAYS read this -->
+        <payara.version></payara.version>
         <payara.home>${project.build.directory}${file.separator}payara6</payara.home>
 
         <payara.arquillian.version>3.0.alpha6</payara.arquillian.version>

--- a/batch-tck/pom.xml
+++ b/batch-tck/pom.xml
@@ -33,6 +33,7 @@
         <jakarta.batch.version>2.1.1</jakarta.batch.version>
 
         <!-- Note that Shrinkwrap Maven resolver WILL NOT read in whatever you specify on the command line - it will ALWAYS read this -->
+        <!-- DO NOT COMMIT A VERSION HERE! -->
         <payara.version></payara.version>
         <payara.home>${project.build.directory}${file.separator}payara6</payara.home>
 

--- a/batch-tck/pom.xml
+++ b/batch-tck/pom.xml
@@ -40,6 +40,11 @@
         <payara.arquillian.version>3.0.alpha6</payara.arquillian.version>
         <arquillian.version>1.7.0.Alpha10</arquillian.version>
         <junit.version>5.8.2</junit.version>
+
+        <download.maven.plugin.version>1.6.8</download.maven.plugin.version>
+        <maven.dependency.plugin.version>3.3.0</maven.dependency.plugin.version>
+        <maven.failsafe.plugin.version>3.0.0-M7</maven.failsafe.plugin.version>
+        <maven.antrun.plugin.version>3.1.0</maven.antrun.plugin.version>
     </properties>
 
     <modules>

--- a/batch-tck/pom.xml
+++ b/batch-tck/pom.xml
@@ -30,15 +30,14 @@
     <name>Jakarta Batch TCK Runner for Payara</name>
 
     <properties>
-        <jakarta.batch.api.version>2.1.0</jakarta.batch.api.version>
-        <jakarta.batch.tck.version>2.1.1</jakarta.batch.tck.version>
+        <jakarta.batch.version>2.1.1</jakarta.batch.version>
 
         <payara.version>6.2022.1.Alpha5-SNAPSHOT</payara.version>
         <payara.home>${project.build.directory}${file.separator}payara6</payara.home>
 
         <payara.arquillian.version>3.0.alpha6</payara.arquillian.version>
         <arquillian.version>1.7.0.Alpha10</arquillian.version>
-        <junit.version>5.9.0</junit.version>
+        <junit.version>5.8.2</junit.version>
     </properties>
 
     <modules>

--- a/batch-tck/sigtests/pom.xml
+++ b/batch-tck/sigtests/pom.xml
@@ -10,143 +10,16 @@
 
     <artifactId>batch-tck.sig-tests</artifactId>
 
-    <repositories>
-        <repository>
-            <id>jakarta-snapshots</id>
-            <url>https://jakarta.oss.sonatype.org/content/repositories/staging/</url>
-        </repository>
-        <repository>
-            <id>central</id>
-            <url>https://repo1.maven.org/maven2</url>
-        </repository>
-        <repository>
-            <id>jboss</id>
-            <url>https://repository.jboss.org/nexus/content/repositories/releases/</url>
-        </repository>
-
-        <!-- Payara Community Repos -->
-        <repository>
-            <id>payara-nexus-artifacts</id>
-            <url>https://nexus.payara.fish/repository/payara-artifacts</url>
-        </repository>
-        <repository>
-            <id>payara-nexus-snapshots</id>
-            <url>https://nexus.payara.fish/repository/payara-snapshots</url>
-        </repository>
-
-        <!-- Payara Enterprise repos -->
-        <repository>
-            <id>payara-nexus-enterprise-distributions</id>
-            <url>https://nexus.payara.fish/repository/payara-enterprise</url>
-        </repository>
-        <repository>
-            <id>payara-nexus-enterprise-artifacts</id>
-            <url>https://nexus.payara.fish/repository/payara-enterprise-artifacts-private</url>
-        </repository>
-        <repository>
-            <id>payara-nexus-enterprise-snapshots</id>
-            <url>https://nexus.payara.fish/repository/payara-enterprise-snapshots-private</url>
-        </repository>
-    </repositories>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>payara-nexus-artifacts</id>
-            <url>https://nexus.payara.fish/repository/payara-artifacts</url>
-        </pluginRepository>
-    </pluginRepositories>
-            
-    <profiles>
-        <profile>
-            <id>jdk11</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-                <jdk>11</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.netbeans.tools</groupId>
-                        <artifactId>sigtest-maven-plugin</artifactId>
-                        <configuration>
-                            <sigfile>${project.build.directory}/sigtest-copy/sigtest/sigtest-1.6-batch.standalone.tck.sig-2.1-se11-OpenJDK-J9</sigfile>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>jdk17</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-                <jdk>17</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.netbeans.tools</groupId>
-                        <artifactId>sigtest-maven-plugin</artifactId>
-                        <configuration>
-                            <sigfile>${project.build.directory}/sigtest-copy/sigtest/sigtest-1.6-batch.standalone.tck.sig-2.1-se17-TemurinHotSpot</sigfile>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>payara-server-managed</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-
-            <dependencies>
-                <dependency>
-                    <groupId>fish.payara.arquillian</groupId>
-                    <artifactId>arquillian-payara-server-managed</artifactId>
-                    <version>${payara.arquillian.version}</version>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
-
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>unpack-payara</id>
-                                <phase>pre-integration-test</phase>
-                                <goals>
-                                    <goal>unpack</goal>
-                                </goals>
-                                <configuration>
-                                    <artifactItems>
-                                        <artifactItem>
-                                            <groupId>fish.payara.distributions</groupId>
-                                            <artifactId>payara</artifactId>
-                                            <version>${payara.version}</version>
-                                            <type>zip</type>
-                                            <overWrite>false</overWrite>
-                                            <outputDirectory>${project.build.directory}</outputDirectory>
-                                        </artifactItem>
-                                    </artifactItems>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
+    <properties>
+        <sigtest.maven.plugin.version>1.6</sigtest.maven.plugin.version>
+    </properties>
 
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>${maven.dependency.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>unpack-sigfiles</id>
@@ -170,18 +43,18 @@
             </plugin>
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>${maven.antrun.plugin.version}</version>
                 <executions>
                     <execution>
-                        <id>default-cli</id>
+                        <id>expand-payara-modules</id>
                         <phase>pre-integration-test</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>
                         <configuration>
                             <target>
-                                <unzip dest="${project.build.directory}/classes">
-                                    <fileset dir="${payara.home}/glassfish/modules">
+                                <unzip dest="${project.build.directory}${file.separator}classes">
+                                    <fileset dir="${payara.home}${file.separator}glassfish${file.separator}modules">
                                         <include name="*.jar"/>
                                     </fileset>
                                 </unzip>
@@ -193,10 +66,10 @@
             <plugin>
                 <groupId>org.netbeans.tools</groupId>
                 <artifactId>sigtest-maven-plugin</artifactId>
-                <version>1.6</version>
+                <version>${sigtest.maven.plugin.version}</version>
                 <executions>
                     <execution>
-                        <id>default-cli</id>
+                        <id>sigtest</id>
                         <phase>integration-test</phase>
                         <goals>
                             <goal>check</goal>
@@ -211,4 +84,97 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>jdk11</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <jdk>11</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.netbeans.tools</groupId>
+                        <artifactId>sigtest-maven-plugin</artifactId>
+                        <configuration>
+                            <sigfile>${project.build.directory}${file.separator}sigtest-copy${file.separator}sigtest${file.separator}sigtest-1.6-batch.standalone.tck.sig-2.1-se11-OpenJDK-J9</sigfile>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>jdk17</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <jdk>17</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.netbeans.tools</groupId>
+                        <artifactId>sigtest-maven-plugin</artifactId>
+                        <configuration>
+                            <sigfile>${project.build.directory}${file.separator}sigtest-copy${file.separator}sigtest${file.separator}sigtest-1.6-batch.standalone.tck.sig-2.1-se17-TemurinHotSpot</sigfile>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>payara-server-managed</id>
+            <activation>
+                <property>
+                    <name>!payara.server.remote</name>
+                </property>
+            </activation>
+
+            <properties>
+                <payara.server.managed/>
+            </properties>
+
+            <dependencies>
+                <dependency>
+                    <groupId>fish.payara.arquillian</groupId>
+                    <artifactId>arquillian-payara-server-managed</artifactId>
+                    <version>${payara.arquillian.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <version>${maven.dependency.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>unpack-payara</id>
+                                <phase>generate-test-resources</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>!${skipITs}</skip>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>fish.payara.distributions</groupId>
+                                            <artifactId>payara</artifactId>
+                                            <version>${payara.version}</version>
+                                            <type>zip</type>
+                                            <overWrite>false</overWrite>
+                                            <outputDirectory>${project.build.directory}</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/batch-tck/sigtests/pom.xml
+++ b/batch-tck/sigtests/pom.xml
@@ -10,14 +10,6 @@
 
     <artifactId>batch-tck.sig-tests</artifactId>
 
-    <properties>
-        <payara.version>6.2022.1.Alpha5-SNAPSHOT</payara.version>
-        <payara.home>${project.build.directory}${file.separator}payara6</payara.home>
-
-        <payara.arquillian.version>3.0.alpha6</payara.arquillian.version>
-        <arquillian.version>1.7.0.Alpha10</arquillian.version>
-    </properties>
-
     <repositories>
         <repository>
             <id>jakarta-snapshots</id>

--- a/batch-tck/sigtests/pom.xml
+++ b/batch-tck/sigtests/pom.xml
@@ -2,15 +2,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <!-- We don't use the root module as a parent because it brings unnecessary dependencies, which we can't exclude from the sigtest classpath -->
-    <groupId>fish.payara.jakarta.tests.tck</groupId>
+    <parent>
+        <groupId>fish.payara.jakarta.tests.tck</groupId>
+        <artifactId>batch-tck</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
     <artifactId>batch-tck.sig-tests</artifactId>
-    <version>2.1.0</version>
 
     <properties>
         <payara.version>6.2022.1.Alpha5-SNAPSHOT</payara.version>
         <payara.home>${project.build.directory}${file.separator}payara6</payara.home>
-        <jakarta.batch.version>2.1.0</jakarta.batch.version>
 
         <payara.arquillian.version>3.0.alpha6</payara.arquillian.version>
         <arquillian.version>1.7.0.Alpha10</arquillian.version>

--- a/batch-tck/sigtests/pom.xml
+++ b/batch-tck/sigtests/pom.xml
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <!-- We don't use the root module as a parent because it brings unnecessary dependencies, which we can't exclude from the sigtest classpath -->
+    <groupId>fish.payara.jakarta.tests.tck</groupId>
+    <artifactId>batch-tck.sig-tests</artifactId>
+    <version>2.1.0</version>
+
+    <properties>
+        <payara.version>6.2022.1.Alpha5-SNAPSHOT</payara.version>
+        <payara.home>${project.build.directory}${file.separator}payara6</payara.home>
+        <jakarta.batch.version>2.1.0</jakarta.batch.version>
+
+        <payara.arquillian.version>3.0.alpha6</payara.arquillian.version>
+        <arquillian.version>1.7.0.Alpha10</arquillian.version>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>jakarta-snapshots</id>
+            <url>https://jakarta.oss.sonatype.org/content/repositories/staging/</url>
+        </repository>
+        <repository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2</url>
+        </repository>
+        <repository>
+            <id>jboss</id>
+            <url>https://repository.jboss.org/nexus/content/repositories/releases/</url>
+        </repository>
+
+        <!-- Payara Community Repos -->
+        <repository>
+            <id>payara-nexus-artifacts</id>
+            <url>https://nexus.payara.fish/repository/payara-artifacts</url>
+        </repository>
+        <repository>
+            <id>payara-nexus-snapshots</id>
+            <url>https://nexus.payara.fish/repository/payara-snapshots</url>
+        </repository>
+
+        <!-- Payara Enterprise repos -->
+        <repository>
+            <id>payara-nexus-enterprise-distributions</id>
+            <url>https://nexus.payara.fish/repository/payara-enterprise</url>
+        </repository>
+        <repository>
+            <id>payara-nexus-enterprise-artifacts</id>
+            <url>https://nexus.payara.fish/repository/payara-enterprise-artifacts-private</url>
+        </repository>
+        <repository>
+            <id>payara-nexus-enterprise-snapshots</id>
+            <url>https://nexus.payara.fish/repository/payara-enterprise-snapshots-private</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>payara-nexus-artifacts</id>
+            <url>https://nexus.payara.fish/repository/payara-artifacts</url>
+        </pluginRepository>
+    </pluginRepositories>
+            
+    <profiles>
+        <profile>
+            <id>jdk11</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <jdk>11</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.netbeans.tools</groupId>
+                        <artifactId>sigtest-maven-plugin</artifactId>
+                        <configuration>
+                            <sigfile>${project.build.directory}/sigtest-copy/sigtest/sigtest-1.6-batch.standalone.tck.sig-2.1-se11-OpenJDK-J9</sigfile>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>jdk17</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <jdk>17</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.netbeans.tools</groupId>
+                        <artifactId>sigtest-maven-plugin</artifactId>
+                        <configuration>
+                            <sigfile>${project.build.directory}/sigtest-copy/sigtest/sigtest-1.6-batch.standalone.tck.sig-2.1-se17-TemurinHotSpot</sigfile>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>payara-server-managed</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+
+            <dependencies>
+                <dependency>
+                    <groupId>fish.payara.arquillian</groupId>
+                    <artifactId>arquillian-payara-server-managed</artifactId>
+                    <version>${payara.arquillian.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack-payara</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>fish.payara.distributions</groupId>
+                                            <artifactId>payara</artifactId>
+                                            <version>${payara.version}</version>
+                                            <type>zip</type>
+                                            <overWrite>false</overWrite>
+                                            <outputDirectory>${project.build.directory}</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <id>unpack-sigfiles</id>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <phase>pre-integration-test</phase>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>jakarta.batch</groupId>
+                                    <artifactId>com.ibm.jbatch.tck</artifactId>
+                                    <version>${jakarta.batch.version}</version>
+                                </artifactItem>
+                            </artifactItems>
+                            <includes>sigtest/*</includes>
+                            <outputDirectory>${project.build.directory}/sigtest-copy</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>default-cli</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <unzip dest="${project.build.directory}/classes">
+                                    <fileset dir="${payara.home}/glassfish/modules">
+                                        <include name="*.jar"/>
+                                    </fileset>
+                                </unzip>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.netbeans.tools</groupId>
+                <artifactId>sigtest-maven-plugin</artifactId>
+                <version>1.6</version>
+                <executions>
+                    <execution>
+                        <id>default-cli</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <action>strictcheck</action>
+                    <failOnError>true</failOnError>
+                    <packages>jakarta.batch.**</packages>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <ant.zip.url>https://archive.apache.org/dist/ant/binaries/apache-ant-${ant.version}-bin.zip</ant.zip.url>
 
         <payara.home>${project.build.directory}/payara6</payara.home>
-        <payara.version>6.2022.1.Alpha4-SNAPSHOT</payara.version>
+        <payara.version>6.2022.1.Alpha5-SNAPSHOT</payara.version>
         <payara.asadmin>${payara.home}/glassfish/bin/asadmin</payara.asadmin>
 
         <arquillian.version>1.7.0.Alpha10</arquillian.version>
@@ -77,6 +77,7 @@
 
     <modules>
         <module>authorization-tck</module>
+        <module>batch-tck</module>
         <module>cdi-langmodel-tck</module>
         <module>cdi-tck</module>
         <module>concurrent-tck</module>


### PR DESCRIPTION
Adds a TCK runner for Batch.

It's based on the GlassFish runner, but quite heavily edited for use with Payara.

The Batch TCK makes use of Shrinkwrap Maven resolver, which is extremely annoying in that it ignores properties you define on the command line, it will **always** read the pom as-is - hence why `payara.version` is left purposefully blank and the README says to fill it in yourself.