### PR TITLE
FISH-6538 Activate Authentication Old-TCK

### DIFF
--- a/authentication-tck/old-tck-run.xml
+++ b/authentication-tck/old-tck-run.xml
@@ -1,0 +1,356 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.ee4j.tck.authentication</groupId>
+        <artifactId>old-authentication-tck-parent</artifactId>
+        <version>3.0.1</version>
+    </parent>
+
+    <artifactId>glassfish-external-tck-authentication</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Old Jakarta Authentication TCK - run</name>
+
+    <properties>
+        <ant.version>1.10.11</ant.version>
+        <ant.home>${project.build.directory}/apache-ant-${ant.version}</ant.home>
+        <ant.zip.url>https://archive.apache.org/dist/ant/binaries/apache-ant-${ant.version}-bin.zip</ant.zip.url>
+
+        <tck.home>${project.build.directory}/authentication-tck</tck.home>
+        <tck.tests.home>${tck.home}/src/com/sun/ts/tests/jaspic</tck.tests.home>
+        <tck.mode>standalone</tck.mode>
+        <payara.home>${project.build.directory}/payara6</payara.home>
+        <glassfish.asadmin>${payara.home}/glassfish/bin/asadmin</glassfish.asadmin>
+        <jakartaee.profile>full</jakartaee.profile>
+        <glassfish.artifact>glassfish</glassfish.artifact>
+        <glassfish.version>7.0.0-M5</glassfish.version>
+
+
+        <jacoco.includes>org/glassfish/**\:com/sun/enterprise/**</jacoco.includes>
+
+        <port.admin>4848</port.admin>
+        <port.derby>1527</port.derby>
+        <port.http>8080</port.http>
+        <port.https>8181</port.https>
+        <port.jms>7676</port.jms>
+        <port.jmx>8686</port.jmx>
+        <port.orb>3700</port.orb>
+        <port.orb.mutual>3920</port.orb.mutual>
+        <port.orb.ssl>3820</port.orb.ssl>
+        <port.harness.log>2000</port.harness.log>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>fish.payara.distributions</groupId>
+            <artifactId>payara</artifactId>
+            <version>${payara.version}</version>
+            <type>zip</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.ee4j.tck.authentication</groupId>
+            <artifactId>old-authentication-tck</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <artifactId>download-maven-plugin</artifactId>
+                <version>1.6.7</version>
+                <executions>
+                    <execution>
+                        <id>download-ant</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <skip>${skipITs}</skip>
+                    <url>${ant.zip.url}</url>
+                    <unpack>true</unpack>
+                    <outputDirectory>${project.build.directory}</outputDirectory>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <skip>${skipITs}</skip>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>unpack-payara</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeArtifactIds>payara</includeArtifactIds>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>unpack-tck</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeArtifactIds>old-authentication-tck</includeArtifactIds>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.1.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.ant</groupId>
+                        <artifactId>ant</artifactId>
+                        <version>${ant.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>ant-contrib</groupId>
+                        <artifactId>ant-contrib</artifactId>
+                        <version>1.0b3</version>
+                        <exclusions>
+                            <exclusion>
+                                <groupId>ant</groupId>
+                                <artifactId>ant</artifactId>
+                            </exclusion>
+                        </exclusions>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <skip>${skipITs}</skip>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>prepare-tck-and-payara</id>
+                        <phase>pre-integration-test</phase>
+                        <configuration>
+                            <target xmlns:if="ant:if" xmlns:unless="ant:unless">
+                                <taskdef resource="net/sf/antcontrib/antcontrib.properties"
+                                         classpathref="maven.plugin.classpath" />
+
+                                <macrodef name="tck-setting">
+                                    <attribute name="key" /> <attribute name="value" />
+                                    <sequential>
+                                        <replaceregexp file="${tck.home}/bin/ts.jte" byline="true"
+                                                       match="@{key}=.*" replace="@{key}=@{value}" />
+                                    </sequential>
+                                </macrodef>
+
+                                <macrodef name="tck-add">
+                                    <attribute name="key" /> <attribute name="value" />
+                                    <sequential>
+                                        <concat append="true" destfile="${tck.home}/bin/ts.jte">@{key}=@{value}${line.separator}</concat>
+                                    </sequential>
+                                </macrodef>
+
+
+                                <!-- Change configuration -->
+                                <tck-setting key="jaspic.home" value="${payara.home}/glassfish"/>
+                                <tck-setting key="harness.log.traceflag" value="true"/>
+
+                                <tck-setting key="webServerHost" value="localhost"/>
+                                <tck-setting key="webServerPort" value="${port.http}"/>
+                                <tck-setting key="orb.port" value="${port.orb}"/>
+                                <tck-setting key="wsgen.ant.classname" value="com.sun.tools.ws.ant.WsGen"/>
+                                <tck-setting key="wsimport.ant.classname" value="com.sun.tools.ws.ant.WsImport"/>
+
+
+
+                                <tck-setting key="report.dir" value="${tck.home}/authenticationtckreport/authenticationtck"/>
+                                <tck-setting key="work.dir" value="${tck.home}/authenticationtckwork/authenticationtck"/>
+
+                                <!--
+                                    # It's an open question why these settings are not just part of ts.jte to begin with.
+                                    # It's also an open question why the Authentication TCK insists on these being defined
+                                -->
+
+                                <tck-add key="persistence.unit.name.2" value="JPATCK2"/>
+                                <tck-add key="persistence.unit.name" value="CTS-EM"/>
+                                <tck-add key="jakarta.persistence.provider" value="org.eclipse.persistence.jpa.PersistenceProvider"/>
+                                <tck-add key="jakarta.persistence.jdbc.driver" value="org.apache.derby.jdbc.ClientDriver"/>
+                                <tck-add key="jakarta.persistence.jdbc.url" value="jdbc:derby://localhost:${port.derby}/derbyDB;create=true"/>
+                                <tck-add key="jakarta.persistence.jdbc.user" value="cts1"/>
+                                <tck-add key="jakarta.persistence.jdbc.password" value="cts1"/>
+                                <tck-add key="jpa.provider.implementation.specific.properties" value="eclipselink.logging.level=OFF"/>
+                                <tck-add key="persistence.second.level.caching.supported" value="true"/>
+
+                                <limit maxwait="240">
+                                    <exec executable="${glassfish.asadmin}" dir="${payara.home}/glassfish/bin">
+                                        <arg value="start-domain"/>
+                                    </exec>
+
+                                    <if>
+                                        <isset property="jacoco.version" />
+                                        <then>
+                                            <exec executable="${glassfish.asadmin}" dir="${payara.home}/glassfish/bin">
+                                                <arg value="create-jvm-options" />
+                                                <arg value="--port=${port.admin}" />
+                                                <arg value="&quot;-javaagent\:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco-it.exec,includes=${jacoco.includes}&quot;" />
+                                            </exec>
+                                        </then>
+                                    </if>
+                                    <exec executable="${glassfish.asadmin}" dir="${payara.home}/glassfish/bin">
+                                        <arg value="stop-domain"/>
+                                        <arg value="domain1"/>
+                                    </exec>
+                                </limit>
+                                <mkdir dir="${tck.home}/authenticationtckreport"/>
+                                <mkdir dir="${tck.home}/authenticationtckreport/authenticationtck"/>
+                                <mkdir dir="${tck.home}/authenticationtckwork"/>
+
+
+                                <replace file="${tck.home}/bin/xml/ts.top.import.xml">
+                                    <replacetoken><![CDATA[<jvmarg value="-Xmx512m"/>]]></replacetoken>
+                                    <replacevalue><![CDATA[<jvmarg value="-Xmx512m"/>
+                                <jvmarg value="-Djavatest.security.noSecurityManager=true"/>]]></replacevalue>
+                                </replace>
+
+                                <replace file="${tck.home}/bin/xml/ts.top.import.xml" if:set="suspend-tck" >
+                                    <replacetoken><![CDATA[<jvmarg value="-Xmx512m"/>]]></replacetoken>
+                                    <replacevalue><![CDATA[<jvmarg value="-Xmx512m"/>
+                                <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=9008"/>]]></replacevalue>
+                                </replace>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+
+                    <execution>
+                        <id>configure-tck-tests</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <taskdef resource="net/sf/antcontrib/antcontrib.properties"
+                                         classpathref="maven.plugin.classpath" />
+
+                                <exec executable="${ant.home}/bin/ant" dir="${tck.home}/bin">
+                                    <arg value="config.vi"  />
+                                </exec>
+                                <exec executable="${ant.home}/bin/ant" dir="${tck.home}/bin">
+                                    <arg value="enable.jaspic"  />
+                                </exec>
+                                <exec executable="${glassfish.asadmin}" dir="${payara.home}/glassfish/bin">
+                                    <arg value="stop-domain"/>
+                                    <arg value="domain1"/>
+                                </exec>
+                                <limit maxwait="120">
+                                    <exec executable="${glassfish.asadmin}" dir="${payara.home}/glassfish/bin">
+                                        <arg value="start-domain"/>
+                                    </exec>
+                                </limit>
+                            </target>
+                        </configuration>
+                    </execution>
+
+
+                    <execution>
+                        <id>run-tck-tests</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target xmlns:if="ant:if" xmlns:unless="ant:unless">
+                                <taskdef resource="net/sf/antcontrib/antcontrib.properties"
+                                         classpathref="maven.plugin.classpath" />
+
+                                <echo level="info" message="Start running all tests" />
+                                <exec executable="${ant.home}/bin/ant" dir="${tck.home}/bin" resultproperty="testResult">
+                                    <arg value="-Dutil.dir=${tck.home}"  />
+                                    <arg value="-Dmultiple.tests=${run.test}" if:set="run.test" />
+                                    <arg value="-Dkeywords=${KEYWORDS}" if:set="KEYWORDS"/>
+                                    <arg value="run.all" unless:set="run.test"/>
+                                    <arg value="runclient" if:set="run.test" />
+                                    <env key="LC_ALL" value="C" />
+                                </exec>
+
+                                <if>
+                                    <not>
+                                        <equals arg1="${testResult}" arg2="0" />
+                                    </not>
+                                    <then>
+                                        <echo message="Running tests failed." />
+                                        <loadfile property="contents" srcFile="${payara.home}/glassfish/domains/domain1/logs/server.log" />
+                                        <echo message="${contents}" />
+                                    </then>
+                                </if>
+
+                                <exec executable="${glassfish.asadmin}" dir="${payara.home}/glassfish/bin">
+                                    <arg value="stop-domain" />
+                                </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+    <profiles>
+        <!-- ### JakartaEE Platform Mode (by default tck.mode=standalone, KEYWORDS=all)### -->
+        <profile>
+            <id>platform</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <tck.mode>platform</tck.mode>
+                <KEYWORDS>jaspic_baseline|javaee</KEYWORDS>
+            </properties>
+        </profile>
+
+        <!-- ### GlassFish Web Profile### -->
+        <profile>
+            <id>web</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <jakartaee.profile>web</jakartaee.profile>
+                <glassfish.artifact>web</glassfish.artifact>
+                <KEYWORDS>jaspic_web_profile</KEYWORDS>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/authentication-tck/old-tck-run.xml
+++ b/authentication-tck/old-tck-run.xml
@@ -39,11 +39,10 @@
         <tck.tests.home>${tck.home}/src/com/sun/ts/tests/jaspic</tck.tests.home>
         <tck.mode>standalone</tck.mode>
         <payara.home>${project.build.directory}/payara6</payara.home>
-        <glassfish.asadmin>${payara.home}/glassfish/bin/asadmin</glassfish.asadmin>
+        <payara.asadmin>${payara.home}/glassfish/bin/asadmin</payara.asadmin>
         <jakartaee.profile>full</jakartaee.profile>
-        <glassfish.artifact>glassfish</glassfish.artifact>
-        <glassfish.version>7.0.0-M5</glassfish.version>
 
+	<payara.artifact>payara</payara.artifact>
 
         <jacoco.includes>org/glassfish/**\:com/sun/enterprise/**</jacoco.includes>
 
@@ -62,7 +61,7 @@
     <dependencies>
         <dependency>
             <groupId>fish.payara.distributions</groupId>
-            <artifactId>payara</artifactId>
+            <artifactId>${payara.artifact}</artifactId>
             <version>${payara.version}</version>
             <type>zip</type>
             <scope>test</scope>
@@ -188,7 +187,7 @@
                                 <tck-setting key="orb.port" value="${port.orb}"/>
                                 <tck-setting key="wsgen.ant.classname" value="com.sun.tools.ws.ant.WsGen"/>
                                 <tck-setting key="wsimport.ant.classname" value="com.sun.tools.ws.ant.WsImport"/>
-
+                                <tck-setting key="vendor.authconfig.factory" value="com.sun.enterprise.security.jaspic.config.GFAuthConfigFactory"/>
 
 
                                 <tck-setting key="report.dir" value="${tck.home}/authenticationtckreport/authenticationtck"/>
@@ -210,21 +209,21 @@
                                 <tck-add key="persistence.second.level.caching.supported" value="true"/>
 
                                 <limit maxwait="240">
-                                    <exec executable="${glassfish.asadmin}" dir="${payara.home}/glassfish/bin">
+                                    <exec executable="${payara.asadmin}" dir="${payara.home}/glassfish/bin">
                                         <arg value="start-domain"/>
                                     </exec>
 
                                     <if>
                                         <isset property="jacoco.version" />
                                         <then>
-                                            <exec executable="${glassfish.asadmin}" dir="${payara.home}/glassfish/bin">
+                                            <exec executable="${payara.asadmin}" dir="${payara.home}/glassfish/bin">
                                                 <arg value="create-jvm-options" />
                                                 <arg value="--port=${port.admin}" />
                                                 <arg value="&quot;-javaagent\:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco-it.exec,includes=${jacoco.includes}&quot;" />
                                             </exec>
                                         </then>
                                     </if>
-                                    <exec executable="${glassfish.asadmin}" dir="${payara.home}/glassfish/bin">
+                                    <exec executable="${payara.asadmin}" dir="${payara.home}/glassfish/bin">
                                         <arg value="stop-domain"/>
                                         <arg value="domain1"/>
                                     </exec>
@@ -269,12 +268,12 @@
                                 <exec executable="${ant.home}/bin/ant" dir="${tck.home}/bin">
                                     <arg value="enable.jaspic"  />
                                 </exec>
-                                <exec executable="${glassfish.asadmin}" dir="${payara.home}/glassfish/bin">
+                                <exec executable="${payara.asadmin}" dir="${payara.home}/glassfish/bin">
                                     <arg value="stop-domain"/>
                                     <arg value="domain1"/>
                                 </exec>
                                 <limit maxwait="120">
-                                    <exec executable="${glassfish.asadmin}" dir="${payara.home}/glassfish/bin">
+                                    <exec executable="${payara.asadmin}" dir="${payara.home}/glassfish/bin">
                                         <arg value="start-domain"/>
                                     </exec>
                                 </limit>
@@ -315,7 +314,7 @@
                                     </then>
                                 </if>
 
-                                <exec executable="${glassfish.asadmin}" dir="${payara.home}/glassfish/bin">
+                                <exec executable="${payara.asadmin}" dir="${payara.home}/glassfish/bin">
                                     <arg value="stop-domain" />
                                 </exec>
                             </target>
@@ -348,7 +347,7 @@
             </activation>
             <properties>
                 <jakartaee.profile>web</jakartaee.profile>
-                <glassfish.artifact>web</glassfish.artifact>
+                <payara.artifact>payara-web</payara.artifact>
                 <KEYWORDS>jaspic_web_profile</KEYWORDS>
             </properties>
         </profile>

--- a/authentication-tck/pom-old-tck-run.xml
+++ b/authentication-tck/pom-old-tck-run.xml
@@ -111,7 +111,7 @@
                             <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <includeArtifactIds>payara</includeArtifactIds>
+                            <includeArtifactIds>${payara.artifact}</includeArtifactIds>
                             <outputDirectory>${project.build.directory}</outputDirectory>
                         </configuration>
                     </execution>

--- a/authentication-tck/run-tck.sh
+++ b/authentication-tck/run-tck.sh
@@ -9,4 +9,4 @@ wget -q https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee10/staged/eftl/
 unzip -q target/jakarta-authentication-tck-3.0.1.zip -d target
 sed -i "/<id>custom<\/id>/r payara-profile.xml" target/authentication-tck-3.0.1/tck/pom.xml
 cp old-tck-run.xml target/authentication-tck-3.0.1/tck/old-tck/run/pom.xml
-mvn clean install -Pcustom,old-tck -f target/authentication-tck-3.0.1/tck/pom.xml
+mvn clean install -Pcustom,old-tck,platform -f target/authentication-tck-3.0.1/tck/pom.xml

--- a/authentication-tck/run-tck.sh
+++ b/authentication-tck/run-tck.sh
@@ -8,4 +8,5 @@ mkdir target
 wget -q https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee10/staged/eftl/jakarta-authentication-tck-3.0.1.zip -O target/jakarta-authentication-tck-3.0.1.zip
 unzip -q target/jakarta-authentication-tck-3.0.1.zip -d target
 sed -i "/<id>custom<\/id>/r payara-profile.xml" target/authentication-tck-3.0.1/tck/pom.xml
-mvn clean install -Pcustom -f target/authentication-tck-3.0.1/tck/pom.xml
+cp old-tck-run.xml target/authentication-tck-3.0.1/tck/old-tck/run/pom.xml
+mvn clean install -Pcustom,old-tck -f target/authentication-tck-3.0.1/tck/pom.xml


### PR DESCRIPTION
Activates the Old TCK Module in the authentication TCK.

Replaces the default pom with hard-coded GlassFish replaced by hard-coded Payara, replaces a number of "glassfish" variables with "payara", and also changes the GFAuthConfigFactory signature to the one used in Payara.