### PR TITLE
FISH-6357 Upgrade rest-tck

### DIFF
--- a/rest-tck/pom.xml
+++ b/rest-tck/pom.xml
@@ -21,7 +21,7 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <rest-tck.version>3.1.1</rest-tck.version>
+        <rest-tck.version>3.1.2</rest-tck.version>
         <excluded.groups></excluded.groups>
         <junit.version>5.7.2</junit.version>
 


### PR DESCRIPTION
[tck-download/jakarta-rest-tck](https://github.com/payara/jakartaee-10-tck-runners/tree/main/tck-download/jakarta-rest-tck) is using version 3.1.2 yet the rest-tck itself still using 3.1.1 which is not found in any repository