### PR TITLE
FISH-6646 Concurrency Web Profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,5 @@
 # jakartaee-10-tck-runners
 
-# Concurrent 3.0
-
-### Prerequisities
-
-run
-
-    mvn clean dependency:copy
-    mvn clean dependency:copy-dependencies
-
-* it downloads all server dependencies to target/server-dependencies
-
-Copy the files to Payara:
-
-	cp target/server-dependencies/* ${PAYARA}/glassfish/domains/domain1/lib
-
-Prepare password file for account javajoe/javajoe/role=Manager. File`prepare-server-password` contains row:
-
-	AS_ADMIN_USERPASSWORD=javajoe
-
-Go to Payara and start the server
-
-	./asadmin start-domain
-
-Create required resources:
-
-    echo "Setting file user javajoe"
-    ./asadmin --passwordfile=prepare-server-password create-file-user --groups=Manager --authrealmname=file javajoe
-    echo "Setting system property jimage.dir", needed for SignatureTestServlet
-    ./asadmin create-system-properties jimage.dir=/tmp
-    echo "Setting allow setAccessible, needed for SignatureTestServlet"
-    ./asadmin create-jvm-options "--add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED"
-    ./asadmin create-jvm-options "--add-opens=java.base/jdk.internal.vm.annotation=ALL-UNNAMED"
-    echo "Setup phase done, stopping Payara"
-    ./asadmin stop-domain
-
-Temporal fix for unknown tag 18: copy default-web.xml to domains/domain1/config
-This sets suppressSmap to false, e.g. smap is not generated. Once Payara will use newer Tomcat, it will be fixed
-and this temporal fix can be removed.
-
-### Running
-
-Run maven test in the TCK Runner directory
-
-	cd concurrent-tck
-    mvn test
-
-
 ## Jakarta JSON Processing
 
 ### Prerequisites

--- a/concurrent-tck/README.md
+++ b/concurrent-tck/README.md
@@ -41,5 +41,8 @@ and this temporal fix can be removed.
 
 Run maven test in the TCK Runner directory
 
-	cd concurrent-tck
     mvn test
+
+For running against Payara Web Profile, activate the `web` profile
+
+    mvn test -Pweb

--- a/concurrent-tck/README.md
+++ b/concurrent-tck/README.md
@@ -5,7 +5,7 @@
 run
 
     mvn clean dependency:copy
-    mvn clean dependency:copy-dependencies
+    mvn dependency:copy-dependencies
 
 * it downloads all server dependencies to target/server-dependencies
 

--- a/concurrent-tck/README.md
+++ b/concurrent-tck/README.md
@@ -1,0 +1,45 @@
+# Concurrent 3.0
+
+### Prerequisities
+
+run
+
+    mvn clean dependency:copy
+    mvn clean dependency:copy-dependencies
+
+* it downloads all server dependencies to target/server-dependencies
+
+Copy the files to Payara:
+
+	cp target/server-dependencies/* ${PAYARA}/glassfish/domains/domain1/lib
+
+Prepare password file for account javajoe/javajoe/role=Manager. File`prepare-server-password` contains row:
+
+	AS_ADMIN_USERPASSWORD=javajoe
+
+Go to Payara and start the server
+
+	./asadmin start-domain
+
+Create required resources:
+
+    echo "Setting file user javajoe"
+    ./asadmin --passwordfile=prepare-server-password create-file-user --groups=Manager --authrealmname=file javajoe
+    echo "Setting system property jimage.dir", needed for SignatureTestServlet
+    ./asadmin create-system-properties jimage.dir=/tmp
+    echo "Setting allow setAccessible, needed for SignatureTestServlet"
+    ./asadmin create-jvm-options "--add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED"
+    ./asadmin create-jvm-options "--add-opens=java.base/jdk.internal.vm.annotation=ALL-UNNAMED"
+    echo "Setup phase done, stopping Payara"
+    ./asadmin stop-domain
+
+Temporal fix for unknown tag 18: copy default-web.xml to domains/domain1/config
+This sets suppressSmap to false, e.g. smap is not generated. Once Payara will use newer Tomcat, it will be fixed
+and this temporal fix can be removed.
+
+### Running
+
+Run maven test in the TCK Runner directory
+
+	cd concurrent-tck
+    mvn test

--- a/concurrent-tck/pom.xml
+++ b/concurrent-tck/pom.xml
@@ -18,6 +18,7 @@
         
         <com.beust-jcommander.version>1.82</com.beust-jcommander.version>
 
+        <tck-suite.xml>src${file.separator}test${file.separator}resources${file.separator}tck-suite.xml</tck-suite.xml>
     </properties>
     
     <!-- The Arquillian test framework -->
@@ -152,11 +153,21 @@
                     <systemPropertyVariables>
                     </systemPropertyVariables>
                     <suiteXmlFiles>
-                        <suiteXmlFile>src/test/resources/tck-suite.xml</suiteXmlFile>
+                        <suiteXmlFile>${tck-suite.xml}</suiteXmlFile>
                     </suiteXmlFiles>
                     <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>web</id>
+
+            <properties>
+                <tck-suite.xml>src${file.separator}test${file.separator}resources${file.separator}tck-suite-web.xml</tck-suite.xml>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/concurrent-tck/pom.xml
+++ b/concurrent-tck/pom.xml
@@ -165,6 +165,13 @@
         <profile>
             <id>web</id>
 
+            <activation>
+                <property>
+                    <name>javaee.level</name>
+                    <value>web</value>
+                </property>
+            </activation>
+
             <properties>
                 <tck-suite.xml>src${file.separator}test${file.separator}resources${file.separator}tck-suite-web.xml</tck-suite.xml>
             </properties>

--- a/concurrent-tck/src/test/resources/tck-suite-web.xml
+++ b/concurrent-tck/src/test/resources/tck-suite-web.xml
@@ -1,6 +1,11 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 <suite name="jakarta-concurrency" verbose="2" configfailurepolicy="continue">
     <test name="jakarta-concurrency.tck">
+        <groups>
+            <run>
+                <exclude name="eefull" />
+            </run>
+        </groups>
         <packages>
             <package name="ee.jakarta.tck.concurrent.api.*"/>
             <package name="ee.jakarta.tck.concurrent.spec.*"/>

--- a/concurrent-tck/src/test/resources/tck-suite.xml
+++ b/concurrent-tck/src/test/resources/tck-suite.xml
@@ -1,6 +1,11 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 <suite name="jakarta-concurrency" verbose="2" configfailurepolicy="continue">
     <test name="jakarta-concurrency.tck">
+        <groups>
+            <run>
+                <exclude name="eefull" />
+            </run>
+        </groups>
         <packages>
             <package name="ee.jakarta.tck.concurrent.api.*"/>
             <package name="ee.jakarta.tck.concurrent.spec.*"/>


### PR DESCRIPTION
Adds a second tck-suite.xml with the expected excluded group - activated via the `web` profile.