### PR TITLE
Fish 6406 fail maven if authorization tests fail

### DIFF
--- a/authorization-tck/pom.xml
+++ b/authorization-tck/pom.xml
@@ -333,6 +333,14 @@
                                 <exec executable="${payara.asadmin}" dir="${payara.home}/glassfish/bin">
                                     <arg value="stop-domain" />
                                 </exec>
+                                
+                                <fail message="Running tests failed." status="${testResult}">
+                                    <condition>
+                                        <not>
+                                            <equals arg1="${testResult}" arg2="0" />
+                                        </not>
+                                    </condition>
+                                </fail>
                             </target>
                         </configuration>
                     </execution>

--- a/authorization-tck/pom.xml
+++ b/authorization-tck/pom.xml
@@ -198,6 +198,10 @@
                                     match="work\.dir=.*"
                                     replace="work\.dir=${tck.home}/jacctckwork/jacctck" />
 
+                                <replaceregexp file="${tck.home}/bin/ts.jte" byline="true"
+                                    match="        -Djavax\.net\.ssl\.trustStore=.*"
+                                    replace="        -Djavax\.net\.ssl\.trustStore=$\\{jacc.home\\}/domains/domain1/config/cacerts\.p12 -Djavax\.net\.ssl\.trustStorePassword=changeit \\\\" />
+
                                 <!-- Run just selected subset tests -->
                                 <replaceregexp file="${tck.home}/bin/build.xml" byline="true"
                                     match="&lt;/project&gt;"

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <ant.zip.url>https://archive.apache.org/dist/ant/binaries/apache-ant-${ant.version}-bin.zip</ant.zip.url>
 
         <payara.home>${project.build.directory}/payara6</payara.home>
-        <payara.version>6.2022.1.Alpha5-SNAPSHOT</payara.version>
+        <payara.version>6.2023.3-SNAPSHOT</payara.version>
         <payara.asadmin>${payara.home}/glassfish/bin/asadmin</payara.asadmin>
         <payara.artifact>payara</payara.artifact>
 


### PR DESCRIPTION
1) Build is fixed, if the test fails, the whole build fails.
2) Adding setup of trustStore password (this was the reason, why the test failed).

How to test:
Checkout, run `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 mvn clean verify -Dpayara.version=6.2023.3-SNAPSHOT`.
If running for a second run, manually remove the target directory.