### PR TITLE
FISH-6479: Fix stanalone xml-ws tck classpath

### DIFF
--- a/xml-ws-tck/run-tck.sh
+++ b/xml-ws-tck/run-tck.sh
@@ -8,8 +8,8 @@ fi
 export TS_HOME=`pwd`/xml-ws-tck
 export PATH=${PATH}:${TS_HOME}/bin
 
-rm jakarta-xml-ws-tck-4.0.0.zip
-wget https://download.eclipse.org/jakartaee/xml-web-services/4.0/jakarta-xml-ws-tck-4.0.0.zip
+#rm jakarta-xml-ws-tck-4.0.0.zip
+wget -c https://download.eclipse.org/jakartaee/xml-web-services/4.0/jakarta-xml-ws-tck-4.0.0.zip
 rm -rf ./xml-ws-tck
 unzip jakarta-xml-ws-tck-4.0.0.zip
 
@@ -36,9 +36,9 @@ if [[ ! -f ${TS_HOME}/bin/ts.jte-origin ]]
 then
    mv ${TS_HOME}/bin/ts.jte ${TS_HOME}/bin/ts.jte-origin
 fi
-sed "s/^webcontainer.home=\$/webcontainer.home=${PAYARA_REPL}glassfish/" ${TS_HOME}/bin/ts.jte-origin > ${TS_HOME}/bin/ts.jte-temp1
-
-mv ${TS_HOME}/bin/ts.jte-temp1 ${TS_HOME}/bin/ts.jte
+sed "s/^webcontainer.home=\$/webcontainer.home=${PAYARA_REPL}glassfish/" ${TS_HOME}/bin/ts.jte-origin > ${TS_HOME}/bin/ts.jte-temp
+sed -E 's#(jaxws.classes=).+#\1${jaxws.lib}/pfl-tf.jar${pathsep}${jaxws.lib}/jakarta.servlet-api.jar${pathsep}${jaxws.lib}/pfl-basic.jar${pathsep}${jaxws.lib}/webservices-api-osgi.jar${pathsep}${jaxws.lib}/webservices-osgi.jar${pathsep}${jaxws.lib}/jaxb-osgi.jar${pathsep}${jaxws.lib}/gmbal.jar${pathsep}${jaxws.lib}/management-api.jar${pathsep}${jaxws.lib}/mimepull.jar${pathsep}${jaxws.lib}/ha-api.jar${pathsep}${jaxws.lib}/jakarta.xml.bind-api.jar${pathsep}${jaxws.lib}/jakarta.activation-api.jar${pathsep}${jaxws.lib}/angus-activation.jar${pathsep}${jaxws.lib}/metro-xmlsec-repackaged.jar#' -i ${TS_HOME}/bin/ts.jte-temp
+mv ${TS_HOME}/bin/ts.jte-temp ${TS_HOME}/bin/ts.jte
 
 mkdir ${TS_HOME}/JTwork
 mkdir ${TS_HOME}/JTreport


### PR DESCRIPTION
Updates `jaxrs.classpath` to jar actually present in current release of Payara 6.

Tested running about 40% of the TCK at time of submission.