### PR TITLE
FISH-6650 servlet tck success when fail

### DIFF
--- a/servlet-tck/pom.xml
+++ b/servlet-tck/pom.xml
@@ -310,6 +310,14 @@
                                 <exec executable="${payara.asadmin}" dir="${payara.home}/glassfish/bin">
                                     <arg value="stop-domain" />
                                 </exec>
+                                
+                                <fail message="Running tests failed." status="${testResult}">
+                                    <condition>
+                                        <not>
+                                            <equals arg1="${testResult}" arg2="0" />
+                                        </not>
+                                    </condition>
+                                </fail>
                             </target>
                         </configuration>
                     </execution>

--- a/websocket-tck/pom.xml
+++ b/websocket-tck/pom.xml
@@ -310,6 +310,14 @@
                                 <exec executable="${payara.asadmin}" dir="${payara.home}/glassfish/bin">
                                     <arg value="stop-domain" />
                                 </exec>
+                                
+                                <fail message="Running tests failed." status="${testResult}">
+                                    <condition>
+                                        <not>
+                                            <equals arg1="${testResult}" arg2="0" />
+                                        </not>
+                                    </condition>
+                                </fail>
                             </target>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Add fail conditions when running Websocket and Servlet TCKs, so the test runs return as a failure instead of a success when at least one test fails