### PR TITLE
FISH-9109:upgrading cditck-porting reference to latest commit 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,4 @@
 	branch = EE10
 [submodule "cdi-tck/cditck-porting"]
 	path = cdi-tck/cditck-porting
-	url = https://github.com/payara/cditck-porting
-	branch = EE10
+	url = https://github.com/payara/cditck-porting.git

--- a/cdi-tck/README.md
+++ b/cdi-tck/README.md
@@ -1,8 +1,7 @@
 # How to Run
-1. Build https://github.com/eclipse-ee4j/glassfish-cdi-porting-tck
-2. Ensure that `payara.home` is set - Maven will add the "${payara.home}/glassfish" for you so don't include that final bit.
-3. Make sure M2_HOME is set.
-4. Make sure MAVEN_HOME is set.
-5. Make sure ANT_HOME is set.
-6. Decide which level of TCK you want to run by defining javaee.level as 'core', 'web', or 'full' (default is full).
+1. Ensure that `payara.home` is set - Maven will add the "${payara.home}/glassfish" for you so don't include that final bit.
+2. Make sure M2_HOME is set.
+3. Make sure MAVEN_HOME is set.
+4. Make sure ANT_HOME is set.
+5. Decide which level of TCK you want to run by defining javaee.level as 'core', or 'full' (default is full).
 6. Run `mvn clean verify -Dpayara.home=x -Djavaee.level=y`


### PR DESCRIPTION
This is to upgrade to the latest changes added for the CDI-4.1 branch on the cditck-porting project and improve tck execution