### PR TITLE
FISH-9156: update of weld versions and dependencies

### DIFF
--- a/cdi-langmodel-tck/pom.xml
+++ b/cdi-langmodel-tck/pom.xml
@@ -19,9 +19,9 @@
         <maven.compiler.release>11</maven.compiler.release>
         <cdi.tck.version>4.1.0</cdi.tck.version>
         <cdi.api.version>4.1.0</cdi.api.version>
-        <weld.version>6.0.0.Beta1</weld.version>
+        <weld.version>6.0.0.Beta4</weld.version>
         <arquillian.version>1.8.0.Final</arquillian.version>
-        <payara.arquillian.version>3.0</payara.arquillian.version>
+        <payara.arquillian.version>4.0.alpha1</payara.arquillian.version>
     </properties>
 
     <dependencies>

--- a/cdi-langmodel-tck/pom.xml
+++ b/cdi-langmodel-tck/pom.xml
@@ -20,8 +20,6 @@
         <cdi.tck.version>4.1.0</cdi.tck.version>
         <cdi.api.version>4.1.0</cdi.api.version>
         <weld.version>6.0.0.Beta4</weld.version>
-        <arquillian.version>1.8.0.Final</arquillian.version>
-        <payara.arquillian.version>4.0.alpha1</payara.arquillian.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Updating to the latest version of weld and payara arquillian to execute cdi lang tck

Manual testing

execution of cdi lang without any issue:

![image](https://github.com/user-attachments/assets/eb351a35-aba1-4eb5-8f1f-bce11f0420ed)

Environment:
ubuntu 20.04, azul jdk 21, maven 3.8.6