### PR TITLE
FISH-9185 Reduce Websocket Sleep

### DIFF
--- a/websocket-tck/pom.xml
+++ b/websocket-tck/pom.xml
@@ -194,7 +194,7 @@
                                     <exec executable="${payara.asadmin}" dir="${payara.home}/glassfish/bin">
                                         <arg value="start-domain"/>
                                     </exec>
-                                    <sleep seconds="60" />
+                                    <sleep seconds="5" />
                                     <if>
                                         <isset property="jacoco.version" />
                                         <then>


### PR DESCRIPTION
Reduce the sleep from 60 seconds to 5.
The block has a timeout of 60 seconds, so the sleep was 100% forcing the block to exit partway through: skipping configuration of jacoco (if set), the enabling of HTTP2 push, and turning off the domain.