### PR TITLE
FISH-9459: adding changes to pass websocket signature test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <!-- Jakarta EE versions -->
         <jakarta-annotations-tck.version>3.0.0</jakarta-annotations-tck.version>
         <jakarta-authorization-tck.version>3.0.0</jakarta-authorization-tck.version>
-        <jakarta.tck.sigtest-maven-plugin.version>2.3</jakarta.tck.sigtest-maven-plugin.version>
+        <jakarta.tck.sigtest-maven-plugin.version>2.2</jakarta.tck.sigtest-maven-plugin.version>
         <jakarta.tck.el.version>6.0.0</jakarta.tck.el.version>
         <jakarta.tck.websocket.version>2.2.0</jakarta.tck.websocket.version>
         <jakarta.tck.bean-validation.version>3.1.1</jakarta.tck.bean-validation.version>

--- a/websocket-tck/pom.xml
+++ b/websocket-tck/pom.xml
@@ -72,30 +72,17 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
-                            <additionalClasspathElements>
-                                <additionalClasspathElement>${payara.home}${file.separator}glassfish${file.separator}modules${file.separator}jakarta.websocket-api.jar</additionalClasspathElement>
-                                <additionalClasspathElement>${payara.home}${file.separator}glassfish${file.separator}modules${file.separator}jakarta.websocket-client-api.jar</additionalClasspathElement>
-                                <additionalClasspathElement>${payara.home}${file.separator}glassfish${file.separator}modules${file.separator}jakarta.servlet-api.jar</additionalClasspathElement>
-                                <additionalClasspathElement>${payara.home}${file.separator}glassfish${file.separator}modules${file.separator}jakarta.enterprise.cdi-api.jar</additionalClasspathElement>
-                                <additionalClasspathElement>${payara.home}${file.separator}glassfish${file.separator}modules${file.separator}tyrus-core.jar</additionalClasspathElement>
-                                <additionalClasspathElement>${payara.home}${file.separator}glassfish${file.separator}modules${file.separator}tyrus-server.jar</additionalClasspathElement>
-                                <additionalClasspathElement>${payara.home}${file.separator}glassfish${file.separator}modules${file.separator}tyrus-spi.jar</additionalClasspathElement>
-                                <additionalClasspathElement>${payara.home}${file.separator}glassfish${file.separator}modules${file.separator}tyrus-container-grizzly-client.jar</additionalClasspathElement>
-                                <additionalClasspathElement>${payara.home}${file.separator}glassfish${file.separator}modules${file.separator}tyrus-container-servlet.jar</additionalClasspathElement>
-                                <additionalClasspathElement>${payara.home}${file.separator}glassfish${file.separator}modules${file.separator}tyrus-client.jar</additionalClasspathElement>
-                                <additionalClasspathElement>${payara.home}${file.separator}glassfish${file.separator}modules${file.separator}tyrus-container-glassfish-ejb.jar</additionalClasspathElement>
-                                <additionalClasspathElement>${payara.home}${file.separator}glassfish${file.separator}modules${file.separator}tyrus-container-glassfish-cdi.jar</additionalClasspathElement>
-                                <additionalClasspathElement>${payara.home}${file.separator}glassfish${file.separator}modules${file.separator}nucleus-grizzly-all.jar</additionalClasspathElement>
-                                <additionalClasspathElement>${payara.home}${file.separator}glassfish${file.separator}modules${file.separator}glassfish-grizzly-extra-all.jar</additionalClasspathElement>
-                            </additionalClasspathElements>
                             <dependenciesToScan>jakarta.tck:websocket-tck-spec-tests</dependenciesToScan>
                             <systemPropertyVariables>
                                 <payara.home>${payara.home}</payara.home>
+                                <jimage.dir>${jimage.dir}</jimage.dir>
                                 <junit.log.traceflag>true</junit.log.traceflag>
                                 <lib.name>websockettck</lib.name>
                                 <ws_wait>5</ws_wait>
                                 <porting.ts.url.class.1>com.sun.ts.tests.websocket.lib.implementation.sun.common.SunRIURL</porting.ts.url.class.1>
-                                <signature.sigTestClasspath>${payara.home}${file.separator}glassfish${file.separator}modules${file.separator}jakarta.websocket-api.jar${path.separator}${payara.home}${file.separator}glassfish${file.separator}modules${file.separator}jakarta.websocket-client-api.jar${path.separator}${jimage.dir}${file.separator}java.base${path.separator}${jimage.dir}${file.separator}java.rmi${path.separator}${jimage.dir}${file.separator}java.sql${path.separator}${jimage.dir}${file.separator}java.naming</signature.sigTestClasspath>
+                                <sigTestClasspath>${payara.home}${file.separator}glassfish${file.separator}modules${file.separator}jakarta.websocket-api.jar${path.separator}${payara.home}${file.separator}glassfish${file.separator}modules${file.separator}jakarta.websocket-client-api.jar${path.separator}${jimage.dir}${file.separator}java.base${path.separator}${jimage.dir}${file.separator}java.rmi${path.separator}${jimage.dir}${file.separator}java.sql${path.separator}${jimage.dir}${file.separator}java.naming</sigTestClasspath>
+                                <harness.log.traceflag>true</harness.log.traceflag>
+                                <cts.harness.debug>true</cts.harness.debug>
                             </systemPropertyVariables>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Fix for websocket signature test

For testing the local execution of tck is passing all tests including signature test:

`
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 737, Failures: 0, Errors: 0, Skipped: 0

[INFO]
[INFO]
[INFO] --- maven-failsafe-plugin:3.3.0:verify (payara-tests) @ websocket-tck-runner ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
`

something to take care regarding latest version of sigtest-maven-plugin was that the latest version is causing the following issue: 

`
Aug 27, 2024 11:11:58 PM com.sun.ts.tests.signaturetest.SigTestDriver runSignatureTest
INFO: ********** Status Report 'jakarta.websocket.server' **********

Aug 27, 2024 11:11:58 PM com.sun.ts.tests.signaturetest.SigTestDriver runSignatureTest

INFO: Duplicate option found -ignorejdkclass.

[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 1.067 s <<< FAILURE! -- in com.sun.ts.tests.websocket.signaturetest.WebSocketSigTestIT
[ERROR] com.sun.ts.tests.websocket.signaturetest.WebSocketSigTestIT.signatureTest -- Time elapsed: 1.065 s <<< ERROR!

java.lang.Exception: SigTest.test1() failed!, diffs found
        at com.sun.ts.tests.signaturetest.SigTest.signatureTest(SigTest.java:260)
        at com.sun.ts.tests.websocket.signaturetest.WebSocketSigTestIT.signatureTest(WebSocketSigTestIT.java:246)
`

that is why to solve this I moved version to 2.2