### PR TITLE
FISH-9019 Update EE11 Batch TCK Runner Config

### DIFF
--- a/batch-tck/apitests/pom.xml
+++ b/batch-tck/apitests/pom.xml
@@ -39,7 +39,6 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
 
         <!-- Used to help determine sh vs. bat -->
         <script.ext/>
-        <payara.executable>${payara.home}${file.separator}glassfish${file.separator}bin${file.separator}asadmin${script.ext}</payara.executable>
 
         <slf4j.version>2.0.16</slf4j.version>
     </properties>
@@ -189,7 +188,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                         <configuration>
                             <skip>${skipTests}</skip>
                             <target if="payara.server.managed" unless="skip.setup">
-                                <exec executable="${payara.executable}">
+                                <exec executable="${payara.asadmin}">
                                     <arg value="start-domain" />
                                 </exec>
                             </target>
@@ -237,7 +236,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                         <configuration>
                             <skip>${skipTests}</skip>
                             <target unless="skip.setup">
-                                <exec executable="${payara.executable}">
+                                <exec executable="${payara.asadmin}">
                                     <arg value="create-jdbc-connection-pool" />
                                     <arg value="--datasourceClassname=org.apache.derby.jdbc.ClientDataSource40" />
                                     <arg value="--resType=javax.sql.DataSource" />
@@ -257,7 +256,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                         <configuration>
                             <skip>${skipTests}</skip>
                             <target unless="skip.setup">
-                                <exec executable="${payara.executable}">
+                                <exec executable="${payara.asadmin}">
                                     <arg value="create-jdbc-resource" />
                                     <arg value="--poolName=batchtck" />
                                     <arg value="jdbc/orderDB" />
@@ -275,7 +274,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                         <configuration>
                             <skip>${skipTests}</skip>
                             <target if="payara.server.managed" unless="skip.setup">
-                                <exec executable="${payara.executable}">
+                                <exec executable="${payara.asadmin}">
                                     <arg value="stop-domain" />
                                 </exec>
                             </target>
@@ -290,7 +289,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                         <configuration>
                             <skip>${skipTests}</skip>
                             <target if="payara.server.remote" unless="skip.setup">
-                                <exec executable="${payara.executable}">
+                                <exec executable="${payara.asadmin}">
                                     <arg value="restart-domain" />
                                 </exec>
                             </target>

--- a/batch-tck/apitests/pom.xml
+++ b/batch-tck/apitests/pom.xml
@@ -32,7 +32,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
     <name>Jakarta Batch API TCK Runner for Payara</name>
 
     <properties>
-        <derby.version>10.15.2.0</derby.version>
+        <derby.version>10.17.1.0</derby.version>
         <derby.zip.url>https://dlcdn.apache.org//db/derby/db-derby-${derby.version}/db-derby-${derby.version}-bin.zip</derby.zip.url>
         <db.download.location>${project.build.directory}${file.separator}db-derby-${derby.version}-bin</db.download.location>
         <payara.db.home>${payara.home}${file.separator}javadb</payara.db.home>
@@ -41,7 +41,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
         <script.ext/>
         <payara.executable>${payara.home}${file.separator}glassfish${file.separator}bin${file.separator}asadmin${script.ext}</payara.executable>
 
-        <slf4j.version>1.7.30</slf4j.version>
+        <slf4j.version>2.0.16</slf4j.version>
     </properties>
 
     <dependencies>
@@ -124,7 +124,6 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
             <plugin>
                 <groupId>com.googlecode.maven-download-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
-                <version>${download.maven.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>download-derby</id>
@@ -133,7 +132,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <skip>${skipITs}</skip>
+                            <skip>${skipTests}</skip>
                             <url>${derby.zip.url}</url>
                             <unpack>true</unpack>
                             <outputDirectory>${project.build.directory}</outputDirectory>
@@ -145,7 +144,6 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>${maven.antrun.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>copy-arquillian-config</id>
@@ -154,7 +152,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <skip>${skipITs}</skip>
+                            <skip>${skipTests}</skip>
                             <target>
                                 <copy file="${project.basedir}${file.separator}src${file.separator}test${file.separator}resources${file.separator}arquillian.xml"
                                       todir="${project.build.directory}${file.separator}test-classes"
@@ -170,7 +168,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <skip>${skipITs}</skip>
+                            <skip>${skipTests}</skip>
                             <target unless="skip.setup">
                                 <move todir="${payara.db.home}">
                                     <fileset dir="${db.download.location}" />
@@ -189,7 +187,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <skip>${skipITs}</skip>
+                            <skip>${skipTests}</skip>
                             <target if="payara.server.managed" unless="skip.setup">
                                 <exec executable="${payara.executable}">
                                     <arg value="start-domain" />
@@ -205,7 +203,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <skip>${skipITs}</skip>
+                            <skip>${skipTests}</skip>
                             <target>
                                 <exec executable="${payara.db.home}${file.separator}bin${file.separator}startNetworkServer${script.ext}" spawn="true" dir="${payara.db.home}"/>
                                 <echo message="Waiting 3 seconds for database in forked process to start..."/>
@@ -221,7 +219,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <skip>${skipITs}</skip>
+                            <skip>${skipTests}</skip>
                             <target>
                                 <exec executable="${payara.db.home}${file.separator}bin${file.separator}ij${script.ext}" dir="${payara.db.home}">
                                     <arg value="${basedir}${file.separator}src${file.separator}test${file.separator}resources${file.separator}derby.ddl.jbatch-tck.sql" />
@@ -237,7 +235,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <skip>${skipITs}</skip>
+                            <skip>${skipTests}</skip>
                             <target unless="skip.setup">
                                 <exec executable="${payara.executable}">
                                     <arg value="create-jdbc-connection-pool" />
@@ -257,7 +255,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <skip>${skipITs}</skip>
+                            <skip>${skipTests}</skip>
                             <target unless="skip.setup">
                                 <exec executable="${payara.executable}">
                                     <arg value="create-jdbc-resource" />
@@ -275,7 +273,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <skip>${skipITs}</skip>
+                            <skip>${skipTests}</skip>
                             <target if="payara.server.managed" unless="skip.setup">
                                 <exec executable="${payara.executable}">
                                     <arg value="stop-domain" />
@@ -290,7 +288,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <skip>${skipITs}</skip>
+                            <skip>${skipTests}</skip>
                             <target if="payara.server.remote" unless="skip.setup">
                                 <exec executable="${payara.executable}">
                                     <arg value="restart-domain" />
@@ -306,7 +304,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <skip>${skipITs}</skip>
+                            <skip>${skipTests}</skip>
                             <target>
                                 <exec executable="${payara.db.home}${file.separator}bin${file.separator}stopNetworkServer${script.ext}" dir="${payara.db.home}"/>
                             </target>
@@ -318,7 +316,6 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>${maven.dependency.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>unpack-tck</id>
@@ -342,7 +339,6 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${maven.failsafe.plugin.version}</version>
                 <configuration>
                     <failIfNoTests>false</failIfNoTests>
                     <systemPropertyVariables>
@@ -372,7 +368,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                             </systemPropertyVariables>
                         </configuration>
                     </execution>
-		    <execution>
+                    <execution>
                         <id>ee-core-suite-web</id>
                         <goals>
                             <goal>integration-test</goal>
@@ -407,7 +403,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
                             </systemPropertyVariables>
                         </configuration>
                     </execution>
-		    <execution>
+                    <execution>
                         <id>appjoboperator-suite-web</id>
                         <goals>
                             <goal>integration-test</goal>

--- a/batch-tck/pom.xml
+++ b/batch-tck/pom.xml
@@ -22,7 +22,12 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>fish.payara.jakarta.tests.tck</groupId>
+    <parent>
+        <groupId>fish.payara.jakarta.tests.tck</groupId>
+        <artifactId>tck</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
     <artifactId>batch-tck</artifactId>
     <version>1.0-SNAPSHOT</version>
 
@@ -30,22 +35,7 @@
     <name>Jakarta Batch TCK Runner for Payara</name>
 
     <properties>
-        <jakarta.batch.version>2.1.1</jakarta.batch.version>
-
-        <!-- Note that Shrinkwrap Maven resolver WILL NOT read in whatever you specify on the command line - it will ALWAYS read this -->
-        <!-- DO NOT COMMIT A VERSION HERE! -->
-        <payara.version></payara.version>
-        <payara.artifact>payara</payara.artifact>
-        <payara.home>${project.build.directory}${file.separator}payara6</payara.home>
-
-        <payara.arquillian.version>3.0.alpha6</payara.arquillian.version>
-        <arquillian.version>1.7.0.Alpha10</arquillian.version>
-        <junit.version>5.8.2</junit.version>
-
-        <download.maven.plugin.version>1.6.8</download.maven.plugin.version>
-        <maven.dependency.plugin.version>3.3.0</maven.dependency.plugin.version>
-        <maven.failsafe.plugin.version>3.0.0-M7</maven.failsafe.plugin.version>
-        <maven.antrun.plugin.version>3.1.0</maven.antrun.plugin.version>
+        <jakarta.batch.version>2.1.5</jakarta.batch.version>
     </properties>
 
     <modules>
@@ -110,94 +100,7 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-
-            <dependency>
-                <groupId>org.jboss.arquillian</groupId>
-                <artifactId>arquillian-bom</artifactId>
-                <version>${arquillian.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.junit</groupId>
-                <artifactId>junit-bom</artifactId>
-                <version>${junit.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
-    <profiles>
-        <profile>
-            <id>payara-server-remote</id>
-
-            <properties>
-                <payara.server.remote/>
-            </properties>
-
-            <dependencies>
-                <dependency>
-                    <groupId>fish.payara.arquillian</groupId>
-                    <artifactId>arquillian-payara-server-remote</artifactId>
-                    <version>${payara.arquillian.version}</version>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-
-        <profile>
-            <id>payara-server-managed</id>
-            <activation>
-                <property>
-                    <name>!payara.server.remote</name>
-                </property>
-            </activation>
-
-            <properties>
-                <payara.server.managed/>
-            </properties>
-
-            <dependencies>
-                <dependency>
-                    <groupId>fish.payara.arquillian</groupId>
-                    <artifactId>arquillian-payara-server-managed</artifactId>
-                    <version>${payara.arquillian.version}</version>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
-
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>unpack-payara</id>
-                                <phase>generate-test-resources</phase>
-                                <goals>
-                                    <goal>unpack</goal>
-                                </goals>
-                                <configuration>
-                                    <skip>!${skipITs}</skip>
-                                    <artifactItems>
-                                        <artifactItem>
-                                            <groupId>fish.payara.distributions</groupId>
-                                            <artifactId>${payara.artifact}</artifactId>
-                                            <version>${payara.version}</version>
-                                            <type>zip</type>
-                                            <overWrite>false</overWrite>
-                                            <outputDirectory>${project.build.directory}</outputDirectory>
-                                        </artifactItem>
-                                    </artifactItems>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/batch-tck/sigtests/pom.xml
+++ b/batch-tck/sigtests/pom.xml
@@ -10,16 +10,11 @@
 
     <artifactId>batch-tck.sig-tests</artifactId>
 
-    <properties>
-        <sigtest.maven.plugin.version>1.6</sigtest.maven.plugin.version>
-    </properties>
-
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>${maven.dependency.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>unpack-sigfiles</id>
@@ -43,7 +38,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>${maven.antrun.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>expand-payara-modules</id>
@@ -64,9 +58,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.netbeans.tools</groupId>
+                <groupId>jakarta.tck</groupId>
                 <artifactId>sigtest-maven-plugin</artifactId>
-                <version>${sigtest.maven.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>sigtest</id>
@@ -87,24 +80,6 @@
 
     <profiles>
         <profile>
-            <id>jdk11</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-                <jdk>11</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.netbeans.tools</groupId>
-                        <artifactId>sigtest-maven-plugin</artifactId>
-                        <configuration>
-                            <sigfile>${project.build.directory}${file.separator}sigtest-copy${file.separator}sigtest${file.separator}sigtest-1.6-batch.standalone.tck.sig-2.1-se11-OpenJDK-J9</sigfile>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>jdk17</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
@@ -113,10 +88,28 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.netbeans.tools</groupId>
+                        <groupId>jakarta.tck</groupId>
                         <artifactId>sigtest-maven-plugin</artifactId>
                         <configuration>
                             <sigfile>${project.build.directory}${file.separator}sigtest-copy${file.separator}sigtest${file.separator}sigtest-1.6-batch.standalone.tck.sig-2.1-se17-TemurinHotSpot</sigfile>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>jdk21</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <jdk>21</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>jakarta.tck</groupId>
+                        <artifactId>sigtest-maven-plugin</artifactId>
+                        <configuration>
+                            <sigfile>${project.build.directory}${file.separator}sigtest-copy${file.separator}sigtest${file.separator}jakarta.sigtest-2.2-batch.standalone.tck.sig-2.1-se21-Temurin</sigfile>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <ant.zip.url>https://archive.apache.org/dist/ant/binaries/apache-ant-${ant.version}-bin.zip</ant.zip.url>
 
         <payara.home>${maven.multiModuleProjectDirectory}${file.separator}target${file.separator}payara7</payara.home>
+        <!-- Note that Shrinkwrap Maven resolver WILL NOT read in whatever you specify on the command line - it will ALWAYS read this as-is -->
         <payara.version>7.2024.1.Alpha2-SNAPSHOT</payara.version>
         <payara.asadmin>${payara.home}${file.separator}glassfish${file.separator}bin${file.separator}asadmin</payara.asadmin>
         <payara.artifact>payara</payara.artifact>
@@ -114,8 +115,7 @@
         <module>activation-tck</module>
         <module>annotations-tck</module>
         <module>authorization-tck</module>
-        <!-- Ignore for now since this module, by design, doesn't have payara.version set - see comment in batch-tck/pom.xml for reason (shrinkwrap maven resolver limitation) -->
-        <!-- <module>batch-tck</module> -->
+        <module>batch-tck</module>
         <module>cdi-langmodel-tck</module>
         <module>cdi-tck</module>
         <module>concurrent-tck</module>
@@ -235,6 +235,12 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>jakarta.tck</groupId>
+                    <artifactId>sigtest-maven-plugin</artifactId>
+                    <version>${jakarta.tck.sigtest-maven-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Updates various dependencies for EE11 and JDK 21, and reintegrates with the main project - shrinkwrap resolver is still an issue, but Jenkins already performs a sed to replace the version for us.

Tested locally using `mvn clean verify -Ppayara-server-managed -pl . -pl batch-tck -pl batch-tck/apitests -pl batch-tck/sigtests`