### PR TITLE
Add `payara-server-remote` Profile for Authorization

### DIFF
--- a/authorization-tck/README.md
+++ b/authorization-tck/README.md
@@ -1,0 +1,24 @@
+# Jakarta Authorization TCK Runner
+
+## Prerequisite
+
+Download and install the TCK into your local Maven repo. 
+From the top-level directory: `mvn clean install -pl . -pl tck-download -pl tck-download/jakarta-authorization-tck -Pjakarta-staging`
+
+## Test Execution
+
+To execute the full TCK against a managed Payara Server
+
+```
+mvn clean verify 
+```
+
+### Debugging
+
+Utilise the `payara-server-remote` profile. 
+This profile expects that the TCK has been run in its entirety at least once to perform the necessary setup.
+
+* Move into the TCK for the rerun: `cd authorization-tck/target/authorization-tck-3.0.0/tck`
+* Install the common TCK module (make sure you don't clean!): `mvn install -Ppayara-server-remote,jakarta-staging -pl . -pl common -DskipTests`
+* Start the configured Payara Server found at `authorization-tck/target/authorization-tck-3.0.0/tck/target/payara7` and attach your debugger
+* Run your specific TCK module test (make sure you don't clean!), for example: `mvn verify -Ppayara-server-remote,jakarta-staging -f app-custom-policy2 -Dit.test=AppCustomPolicy2IT#testAuthenticatedSpecial`

--- a/authorization-tck/payara-pom.xml
+++ b/authorization-tck/payara-pom.xml
@@ -274,5 +274,141 @@
                 <payara.asadmin>${payara.home}/glassfish/bin/asadmin.bat</payara.asadmin>
             </properties>
         </profile>
+        <!--
+            Remote profile for rerunning tests without reapplying config -
+            this expects that the TCK has been run at least once using the payara-server-managed profile
+        -->
+        <profile>
+            <id>payara-server-remote</id>
+            <properties>
+                <payara.version>7.2024.1.Alpha2-SNAPSHOT</payara.version>
+                <payara.suspend>false</payara.suspend>
+                <payara.root>${maven.multiModuleProjectDirectory}/target</payara.root>
+                <payara.home>${payara.root}${file.separator}payara7</payara.home>
+                <payara.asadmin>${payara.home}/glassfish/bin/asadmin</payara.asadmin>
+                <log.file.location>${payara.home}${file.separator}glassfish${file.separator}domains${file.separator}domain1${file.separator}logs</log.file.location>
+
+                <arquillian.version>1.9.1.Final</arquillian.version>
+                <payara.arquillian.version>4.0.alpha1</payara.arquillian.version>
+
+                <junit.version>5.10.3</junit.version>
+
+                <sigtest.api.groupId>jakarta.authorization</sigtest.api.groupId>
+                <sigtest.api.artifactId>jakarta.authorization-vendor-api</sigtest.api.artifactId>
+                <sigtest.api.version>${payara.version}</sigtest.api.version>
+
+                <maven-install-plugin.version>3.1.2</maven-install-plugin.version>
+                <maven-failsafe-plugin.version>3.3.0</maven-failsafe-plugin.version>
+                <maven-dependency-plugin.version>3.7.1</maven-dependency-plugin.version>
+                <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
+            </properties>
+
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit</groupId>
+                        <artifactId>junit-bom</artifactId>
+                        <version>${junit.version}</version>
+                        <type>pom</type>
+                        <scope>import</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.jboss.arquillian</groupId>
+                        <artifactId>arquillian-bom</artifactId>
+                        <version>${arquillian.version}</version>
+                        <type>pom</type>
+                        <scope>import</scope>
+                    </dependency>
+
+                    <dependency>
+                        <groupId>fish.payara.api</groupId>
+                        <artifactId>payara-bom</artifactId>
+                        <version>${payara.version}</version>
+                        <type>pom</type>
+                        <scope>import</scope>
+                    </dependency>
+                    <!-- Old version of junit, we need to define this when using Arquillian 1.9 or higher -->
+                    <dependency>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                        <version>4.13.2</version>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+
+            <dependencies>
+                <dependency>
+                    <groupId>fish.payara.arquillian</groupId>
+                    <artifactId>arquillian-payara-server-remote</artifactId>
+                    <version>${payara.arquillian.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-dependency-plugin</artifactId>
+                            <version>${maven-dependency-plugin.version}</version>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-failsafe-plugin</artifactId>
+                            <version>${maven-failsafe-plugin.version}</version>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-install-plugin</artifactId>
+                            <version>${maven-install-plugin.version}</version>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-antrun-plugin</artifactId>
+                            <version>${maven-antrun-plugin.version}</version>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+
+                <plugins>
+                    <!--
+                        Installs the jakarta.authorization-api.jar from Payara on the filesystem to the
+                        coordinates expected by the signature test.
+                    -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-install-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>install-file</goal>
+                                </goals>
+                                <configuration>
+                                    <file>${payara.home}/glassfish/modules/jakarta.authorization-api.jar</file>
+                                    <groupId>${sigtest.api.groupId}</groupId>
+                                    <artifactId>${sigtest.api.artifactId}</artifactId>
+                                    <version>${sigtest.api.version}</version>
+                                    <packaging>jar</packaging>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <payara.home>${payara.home}</payara.home>
+                                <log.file.location>${log.file.location}</log.file.location>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
This profiles is for rerunning the TCK - it expects that the TCK has been run at least once using the default `payara-server-managed` profile to perform the usual setup.
This allows for easier debug of specific tests, as we won't be chaining runs via exec and instead running "directly".

Note that with how this is now, to utilise this profile you have to install some additional "common" bits from the TCK itself.
The general flow is:
* Run the TCK in the "normal" way: `mvn clean install -pl . -pl tck-download/ -pl tck-download/jakarta-authorization-tck/ -pl authorization-tck/ -Ppayara-server-managed,jakarta-staging`
* Move into the TCK for the rerun: `cd authorization-tck/target/authorization-tck-3.0.0/tck`
* Install the common TCK module (make sure you don't `clean`!): `mvn install -Ppayara-server-remote,jakarta-staging -pl . -pl common/ -DskipTests`
* Start the configured Payara Server found at `authorization-tck/target/authorization-tck-3.0.0/tck/target/payara7`
* Run your specific TCK module test: `mvn verify -Ppayara-server-remote,jakarta-staging -f app-custom-policy2 -Dit.test=AppCustomPolicy2IT#testAuthenticatedSpecial`