### PR TITLE
Decrement Sigtest and JUnit Versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <jakarta-annotations-tck.version>3.0.0</jakarta-annotations-tck.version>
         <jakarta-authorization-tck.version>3.0.0</jakarta-authorization-tck.version>
         <jakarta-rest-tck.version>4.0.0</jakarta-rest-tck.version>
-        <jakarta.tck.sigtest-maven-plugin.version>2.3</jakarta.tck.sigtest-maven-plugin.version>
+        <jakarta.tck.sigtest-maven-plugin.version>2.2</jakarta.tck.sigtest-maven-plugin.version>
         <jakarta.tck.el.version>6.0.0</jakarta.tck.el.version>
         <jakarta.tck.websocket.version>2.2.0</jakarta.tck.websocket.version>
         <jakarta.tck.bean-validation.version>3.1.1</jakarta.tck.bean-validation.version>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <exec-maven-plugin.version>3.3.0</exec-maven-plugin.version>
         <download-maven-plugin.version>1.9.0</download-maven-plugin.version>
         <arquillian.version>1.9.1.Final</arquillian.version>
-        <junit.version>5.11.0</junit.version>
+        <junit.version>5.10.3</junit.version>
         <jimage.dir>${project.build.directory}${file.separator}jdk-bundle</jimage.dir>
         <shrinkwrap.resolver.version>3.3.0</shrinkwrap.resolver.version>
         <shrinkwrap.descriptors.version>2.0.0</shrinkwrap.descriptors.version>


### PR DESCRIPTION
Reverts upgrades introduced in 13afbec9911613ab7a99d33fd0a618c7e311841c
Upgrading these breaks:
* Annotations
* JSONP
* Expression Language
* JAX-RS
* Pages
* WebSockets

Clean TCK run (apart from Concurrency) using this branch : https://jenkins.payara.fish/blue/organizations/jenkins/JakartaEE-11-TCK/detail/JakartaEE-11-TCK/63/pipeline/