### PR TITLE
FISH-10056: adding property to skip setting buffer size from mojarra

### DIFF
--- a/security-tck/run-tck.sh
+++ b/security-tck/run-tck.sh
@@ -9,6 +9,7 @@ wget -q https://download.eclipse.org/jakartaee/security/3.0/jakarta-security-tck
 unzip -q target/jakarta-security-tck-3.0.0.zip -d target
 cp -f payara-profile.xml target/security-tck-3.0.0/tck/pom.xml
 cp -f old-tck-run-payara.xml target/security-tck-3.0.0/tck/old-tck/run/pom.xml
+cp -f web.xml target/security-tck-3.0.0/tck/old-tck/source/src/com/sun/ts/tests/securityapi/ham/customform/base/securityapi_ham_customform_base_web.xml
 
 if [[ "$PROFILE" == "web" || "$PROFILE" == "WEB" ]];then
   mvn clean install help:active-profiles -Ppayara-ci-managed,web -f target/security-tck-3.0.0/tck/pom.xml

--- a/security-tck/web.xml
+++ b/security-tck/web.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0"
+         xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
+         metadata-complete="false">
+    <display-name>securityapi_ham_customform_base</display-name>
+    <context-param>
+        <param-name>jakarta.faces.FACELETS_BUFFER_SIZE</param-name>
+        <param-value>-1</param-value>
+    </context-param>
+</web-app>


### PR DESCRIPTION
Adding property to skip the process to set the buffer size for the response object