### PR TITLE
FISH-10040 Update DI TCK Runner and Submodule for EE11

### DIFF
--- a/inject-tck/build.sh
+++ b/inject-tck/build.sh
@@ -15,7 +15,7 @@ fi
 # Cleanup
 rm -f $PORTING/latest-glassfish.zip
 rm -rf $PORTING/dist/
-rm -rf $PORTING/payara6
+rm -rf $PORTING/payara7
 
 cd $PORTING
 
@@ -27,7 +27,7 @@ if [ ! -f $BUNDLES/jakarta.inject-tck.zip ]; then
   wget https://download.eclipse.org/ee4j/cdi/inject/2.0/jakarta.inject-tck-2.0.2-bin.zip -O $BUNDLES/jakarta.inject-tck.zip
 fi
 if [ ! -f $BUNDLES/jsr299-tck.zip ]; then
-  wget https://download.eclipse.org/ee4j/cdi/4.0/cdi-tck-4.0.13-dist.zip -O $BUNDLES/jsr299-tck.zip
+  wget https://download.eclipse.org/ee4j/cdi/4.1/cdi-tck-4.1.0-dist.zip -O $BUNDLES/jsr299-tck.zip
 fi
 
 unzip -o ${SCRIPTPATH}/bundles/payara.zip -d ${WORKSPACE}
@@ -56,11 +56,17 @@ else
   exit 1
 fi
 
-# Install the porting lib
-cd ${WORKSPACE}/cdi-tck-4.0.13/weld/porting-package-lib
-mvn --global-settings ${WORKSPACE}/settings.xml clean install
+# Download and install Weld porting libs
+echo "+++ Downloading CDI TCK porting libs +++"
+#cd ${WORKSPACE}/cdi-tck-4.1.0/weld/porting-package-lib
+#mvn --global-settings ${WORKSPACE}/settings.xml clean install
+#
+#
+mkdir ${WORKSPACE}/cdi-tck-4.1.0/weld/porting-package-lib
+cp ${SCRIPTPATH}/get-dependencies.xml ${WORKSPACE}/cdi-tck-4.1.0/weld/porting-package-lib/pom.xml
+mvn --global-settings ${WORKSPACE}/settings.xml clean install -f ${WORKSPACE}/cdi-tck-4.1.0/weld/porting-package-lib/pom.xml
 echo "+++ Installed CDI TCK porting libs"
-ls target/dependency
+ls ${WORKSPACE}/cdi-tck-4.1.0/weld/porting-package-lib/target/dependency
 
 #Edit test properties
 export TS_HOME=${WORKSPACE}/330-tck-glassfish-porting
@@ -68,7 +74,7 @@ export REPORT=${WORKSPACE}/330tck-report
 sed -i "s#tck.home=.*#tck.home=${WORKSPACE}/jakarta.inject-tck-2.0.2#g" ${TS_HOME}/build.properties
 sed -i "s#porting.home=.*#porting.home=${TS_HOME}#g" ${TS_HOME}/build.properties
 sed -i "s#glassfish.home=.*#glassfish.home=${WORKSPACE}/payara7/glassfish#g" ${TS_HOME}/build.properties
-sed -i "s#299.tck.home=.*#299.tck.home=${WORKSPACE}/cdi-tck-4.0.13#g" ${TS_HOME}/build.properties
+sed -i "s#299.tck.home=.*#299.tck.home=${WORKSPACE}/cdi-tck-4.1.0#g" ${TS_HOME}/build.properties
 sed -i "s#report.dir=.*#report.dir=${REPORT}#g" ${TS_HOME}/build.properties
 
 #### End of adapted from ditck-porting/docker/build_ditck.sh and ditck-porting/docker/run_ditck.sh ###

--- a/inject-tck/build.sh
+++ b/inject-tck/build.sh
@@ -9,7 +9,7 @@ if [ ! -d ditck-porting ]; then
    git clone https://github.com/payara/ditck-porting
    cd $PORTING
    git fetch origin
-   git checkout EE10
+   git checkout EE11
 fi
 
 # Cleanup

--- a/inject-tck/get-dependencies.xml
+++ b/inject-tck/get-dependencies.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>jakarta.enterprise</groupId>
+        <artifactId>cdi-tck-parent</artifactId>
+        <version>4.1.0</version>
+        <relativePath>../../artifacts/cdi-tck-parent-4.1.0.pom</relativePath>
+    </parent>
+
+    <artifactId>cdi-tck-dist-porting-package</artifactId>
+    <packaging>pom</packaging>
+    <name>CDI TCK Distribution - Weld Porting Package</name>
+
+    <!-- Uncomment and add a version to override version obtained from CDI TCK
+    <properties>
+        <weld.version>6.0.0.Beta4</weld.version>
+    </properties>
+    -->
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-porting-package-tck</artifactId>
+            <version>${weld.version}</version>
+            <optional>true</optional>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-porting-package-tck</artifactId>
+            <version>${weld.version}</version>
+            <optional>true</optional>
+            <scope>compile</scope>
+            <type>test-jar</type>
+            <classifier>sources</classifier>
+        </dependency>
+
+        <!-- The TCK distribution includes weld/porting-package-lib/weld-inject-tck-runner-X.Y.Z-Q-tests.jar which contains two classes showing how Weld passes the CDI TCK -->
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-inject-tck-runner</artifactId>
+            <version>${weld.version}</version>
+            <optional>true</optional>
+            <scope>compile</scope>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-inject-tck-runner</artifactId>
+            <version>${weld.version}</version>
+            <optional>true</optional>
+            <scope>compile</scope>
+            <type>test-jar</type>
+            <classifier>test-sources</classifier>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>dist</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/assembly.xml</descriptor>
+                            </descriptors>
+                            <finalName>${project.build.finalName}</finalName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin> -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <id>copy-jboss-tck-runner</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.jboss.weld</groupId>
+                                    <artifactId>weld-jboss-runner-tck</artifactId>
+                                    <version>${weld.version}</version>
+                                    <classifier>dist</classifier>
+                                    <type>zip</type>
+                                    <overWrite>true</overWrite>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <excludeGroupIds>jakarta.enterprise</excludeGroupIds>
+                            <stripVersion>true</stripVersion>
+                            <overWriteReleases>true</overWriteReleases>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/inject-tck/get-dependencies.xml
+++ b/inject-tck/get-dependencies.xml
@@ -59,25 +59,6 @@
 
     <build>
         <plugins>
-            <!-- <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>dist</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                        <configuration>
-                            <descriptors>
-                                <descriptor>src/main/assembly/assembly.xml</descriptor>
-                            </descriptors>
-                            <finalName>${project.build.finalName}</finalName>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin> -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>


### PR DESCRIPTION
Updates the Dependency Injection runner for EE11.
The porting package stuff which we were using to run against Payara itself (rather than just standalone weld) has been removed from the CDI TCK itself. I have introduced a pom which largely recreates what it does: downloads weld binaries so they can be added to the classpath.