### PR TITLE
FISH-10242 Fix client cert servlet tests

### DIFF
--- a/servlet-tck/pom.xml
+++ b/servlet-tck/pom.xml
@@ -149,7 +149,7 @@
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
-                                    <includes>certificates${file.separator}cts_cert,certificates${file.separator}clientcert.p12</includes>
+                                    <includes>certificates${file.separator}cts_cert,certificates${file.separator}clientcert.jks,certificates${file.separator}clientcert.p12</includes>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>
@@ -163,6 +163,22 @@
                 <version>1.7</version>
                 <executions>
                     <execution>
+                        <id>convert-jks-to-pkcs12</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>importKeystore</goal>
+                        </goals>
+                        <configuration>
+                            <srckeystore>${project.build.testOutputDirectory}/certificates/clientcert.jks</srckeystore>
+                            <destkeystore>${project.build.testOutputDirectory}/certificates/clientcert.p12</destkeystore>
+                            <srcstoretype>JKS</srcstoretype>
+                            <deststoretype>PKCS12</deststoretype>
+                            <srcstorepass>changeit</srcstorepass>
+                            <deststorepass>changeit</deststorepass>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-to-payara</id>
                         <phase>process-test-resources</phase>
                         <goals>
                             <goal>importCertificate</goal>
@@ -289,9 +305,12 @@
                                 <servlet.tck.support.http2Push>true</servlet.tck.support.http2Push>
 
                                 <javax.net.ssl.keyStore>${project.build.testOutputDirectory}${file.separator}certificates${file.separator}clientcert.p12</javax.net.ssl.keyStore>
+                                <javax.net.ssl.keyStoreType>pkcs12</javax.net.ssl.keyStoreType>
                                 <javax.net.ssl.keyStorePassword>changeit</javax.net.ssl.keyStorePassword>
                                 <javax.net.ssl.trustStore>${payara.home}${file.separator}glassfish${file.separator}domains${file.separator}domain1${file.separator}config${file.separator}cacerts.p12</javax.net.ssl.trustStore>
-
+                                <javax.net.ssl.trustStoreType>pkcs12</javax.net.ssl.trustStoreType>
+                                <javax.net.ssl.trustStorePassword>changeit</javax.net.ssl.trustStorePassword>
+                                <jdk.tls.client.protocols>TLSv1.2</jdk.tls.client.protocols>
                                 <!-- Print the content of the deployed archives -->
                                 <servlet.tck.archive.print>true</servlet.tck.archive.print>
 


### PR DESCRIPTION
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO]
[INFO] --- failsafe:3.3.0:verify (verify) @ servlet-tck-runner ---
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for tck 1.0-SNAPSHOT:
[INFO]
[INFO] tck ................................................ SUCCESS [  3.687 s]
[INFO] TCK: Servlet ....................................... SUCCESS [ 22.513 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  26.428 s
[INFO] Finished at: 2025-01-14T13:50:01Z
[INFO] ------------------------------------------------------------------------


[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1716, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO]
[INFO] --- failsafe:3.3.0:verify (verify) @ servlet-tck-runner ---
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for tck 1.0-SNAPSHOT:
[INFO]
[INFO] tck ................................................ SUCCESS [  3.713 s]
[INFO] TCK: Servlet ....................................... SUCCESS [14:04 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------


Needed to add truststore type and pasword and also import keystore to p12 store - also required to use tlsv1.2

Tested with 
mvn clean verify -Dpayara.version=7.2025.1.Alpha1-SNAPSHOT -pl . -pl servlet-tck -Ppayara-server-managed,jakarta-staging -Dit.test=servlet.tck.spec.security.clientcert.ClientCertTests

and 

mvn clean verify -Dpayara.version=7.2025.1.Alpha1-SNAPSHOT -pl . -pl servlet-tck -Ppayara-server-managed,jakarta-staging -Dit.test=servlet.tck.spec.security.clientcertanno.ClientCertAnnoTests