### PR TITLE
FISH-10183: upgrading versions to start derby database used for old tck

### DIFF
--- a/security-tck/old-tck-run-payara.xml
+++ b/security-tck/old-tck-run-payara.xml
@@ -32,9 +32,10 @@
     <name>Old Jakarta Security TCK - run</name>
 
     <properties>
-    	<ant.version>1.10.12</ant.version>
+    	<ant.version>1.10.15</ant.version>
         <ant.home>${project.build.directory}/apache-ant-${ant.version}</ant.home>
         <ant.zip.url>https://archive.apache.org/dist/ant/binaries/apache-ant-${ant.version}-bin.zip</ant.zip.url>
+        <download.maven.plugin>1.13.0</download.maven.plugin>
         
         <tck.home>${project.build.directory}/security-tck</tck.home>
         <tck.tests.home>${tck.home}/src/com/sun/ts/tests</tck.tests.home>
@@ -72,7 +73,7 @@
             <plugin>
                 <groupId>com.googlecode.maven-download-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
-                <version>1.6.8</version>
+                <version>${download.maven.plugin}</version>
                 <executions>
                     <execution>
                         <id>download-ant</id>
@@ -375,7 +376,7 @@
 
                 <payara.db.home>${payara.home}${file.separator}javadb</payara.db.home>
 
-                <derby.version>10.15.2.0</derby.version>
+                <derby.version>10.17.1.0</derby.version>
                 <derby.zip.url>https://dlcdn.apache.org//db/derby/db-derby-${derby.version}/db-derby-${derby.version}-bin.zip</derby.zip.url>
                 <db.download.location>${project.build.directory}${file.separator}db-derby-${derby.version}-bin</db.download.location>
             </properties>
@@ -395,7 +396,7 @@
                     <plugin>
                         <groupId>com.googlecode.maven-download-plugin</groupId>
                         <artifactId>download-maven-plugin</artifactId>
-                        <version>1.6.8</version>
+                        <version>${download.maven.plugin}</version>
                         <executions>
                             <execution>
                                 <id>download-derby</id>

--- a/security-tck/payara-profile.xml
+++ b/security-tck/payara-profile.xml
@@ -638,7 +638,7 @@
             <properties>
                 <payara.root>${maven.multiModuleProjectDirectory}/target</payara.root>
                 <payara.version>7.2024.1.Alpha3-SNAPSHOT</payara.version>
-                <payara.arquillian.container.version>4.0.alpha1</payara.arquillian.container.version>
+                <payara.arquillian.container.version>4.0.alpha2</payara.arquillian.container.version>
                 <payara.artifact>payara</payara.artifact>
                 
                 <sigtest.api.groupId>jakarta.security</sigtest.api.groupId>


### PR DESCRIPTION
Upgrading version for derby to start database

before change the issues reported on logs were:

`
[INFO]      [exec] is.derby.running:
[INFO]      [exec]      [echo] *** There was a problem connecting to DB at jdbc:derby://localhost:1527/derbyDB;create=true
[INFO]      [exec]      [echo] Output:java.sql.SQLNonTransientConnectionException: A network protocol error was encountered and the connection has been terminated: A protocol error (Data Stream Syntax Error) was detected.  Reason: 0x1. Perhaps this is an attempt to open a plaintext connection to an SSL enabled server.
[INFO]      [exec]      [echo] Derby was NOT started successfully
`
and 
`
[WARNING]      [echo] Caused by: javax.naming.NamingException: jdbc/securityAPIDB
[WARNING]      [echo] 	at org.glassfish.soteria.cdi.CdiUtils.jndiLookup(CdiUtils.java:228)
[WARNING]      [echo] 	at org.glassfish.soteria.identitystores.DatabaseIdentityStore.getDataSource(DatabaseIdentityStore.java:173)
[WARNING]      [echo] 	... 39 more
[WARNING]      [echo] 	Suppressed: javax.naming.NamingException: Lookup failed for 'jdbc/securityAPIDB' in SerialContext[myEnv={java.naming.factory.initial=com.sun.enterprise.naming.impl.SerialInitContextFactory, java.naming.factory.state=com.sun.corba.ee.impl.presentation.rmi.JNDIStateFactoryImpl, java.naming.factory.url.pkgs=com.sun.enterprise.naming} [Root exception is javax.naming.NameNotFoundException: securityAPIDB not found]
[WARNING]      [echo] 		at com.sun.enterprise.naming.impl.SerialContext.lookup(SerialContext.java:496)
[WARNING]      [echo] 		at com.sun.enterprise.naming.impl.SerialContext.lookup(SerialContext.java:442)
[WARNING]      [echo] 		at java.naming/javax.naming.InitialContext.lookup(InitialContext.java:409)
[WARNING]      [echo] 		at java.naming/javax.naming.InitialContext.lookup(InitialContext.java:409)
[WARNING]      [echo] 		at org.glassfish.soteria.cdi.CdiUtils.jndiLookup(CdiUtils.java:232)
[WARNING]      [echo] 		... 40 more
`
number of passing tests: 

`
[INFO]      [exec] [javatest.batch] Completed running 83 tests.
[INFO]      [exec] [javatest.batch] Number of Tests Passed      = 60
[INFO]      [exec] [javatest.batch] Number of Tests Failed      = 23
[INFO]      [exec] [javatest.batch] Number of Tests with Errors = 0
`
 the previous error caused to not create the specified database and also configure the datasource with jndi name: jdbc/securityAPIDB

after adding the fix no more errors reported on logs regarding lookup jndi issue for name jdbc/securityAPIDB and the amount of failures were reduced when finishing the old tck execution:

`
[INFO]      [exec] [javatest.batch] Completed running 83 tests.
[INFO]      [exec] [javatest.batch] Number of Tests Passed      = 69
[INFO]      [exec] [javatest.batch] Number of Tests Failed      = 14
[INFO]      [exec] [javatest.batch] Number of Tests with Errors = 0
`

