### PR TITLE
Adjust Runners for Windows

### DIFF
--- a/authentication-tck/README.md
+++ b/authentication-tck/README.md
@@ -8,8 +8,7 @@ From the top-level directory: `mvn clean install -pl . -pl tck-download -pl tck-
 ## Test Execution
 
 ### Managed Server Profile
-NOTE: The payara-server-managed doesn't work on Windows. 
-The `create-system-properties` asadmin command doesn't play well with Windows.
+NOTE: The payara-server-managed doesn't work on Windows.
 
 To execute the full TCK against a managed Payara Server, run from the module directory, replacing the payara.version property.
 

--- a/authentication-tck/payara-profiles.xml
+++ b/authentication-tck/payara-profiles.xml
@@ -130,8 +130,9 @@
                                     </arguments>
                                 </configuration>
                             </execution>
+                            <!-- Use singular create-system-property command to allow this to work on Windows - the asadmin separator of : doesn't play well with Windows paths -->
                             <execution>
-                                <id>create-expected-tck-properties</id>
+                                <id>create-expected-tck-property-j2eelogin.name</id>
                                 <phase>pre-integration-test</phase>
                                 <goals>
                                     <goal>exec</goal>
@@ -141,8 +142,72 @@
                                     <skip>${skipConfig}</skip>
                                     <executable>${payara.asadmin}</executable>
                                     <arguments>
-                                        <argument>create-system-properties</argument>
-                                        <argument>j2eelogin.name=j2ee:j2eelogin.password=j2ee:provider.configuration.file=${provider.configuration.file}:vendor.authconfig.factory=${vendor.authconfig.factory}:log.file.location=${log.file.location}</argument>
+                                        <argument>create-system-property</argument>
+                                        <argument>j2eelogin.name=j2ee</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>create-expected-tck-property-j2eelogin.password</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <inherited>false</inherited>
+                                <configuration>
+                                    <skip>${skipConfig}</skip>
+                                    <executable>${payara.asadmin}</executable>
+                                    <arguments>
+                                        <argument>create-system-property</argument>
+                                        <argument>j2eelogin.password=j2ee</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>create-expected-tck-propertt-provider.configuration.file</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <inherited>false</inherited>
+                                <configuration>
+                                    <skip>${skipConfig}</skip>
+                                    <executable>${payara.asadmin}</executable>
+                                    <arguments>
+                                        <argument>create-system-property</argument>
+                                        <argument>provider.configuration.file=${provider.configuration.file}</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>create-expected-tck-property-vendor.authconfig.factory</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <inherited>false</inherited>
+                                <configuration>
+                                    <skip>${skipConfig}</skip>
+                                    <executable>${payara.asadmin}</executable>
+                                    <arguments>
+                                        <argument>create-system-property</argument>
+                                        <argument>vendor.authconfig.factory=${vendor.authconfig.factory}</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>create-expected-tck-property-log.file.location</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <inherited>false</inherited>
+                                <configuration>
+                                    <skip>${skipConfig}</skip>
+                                    <executable>${payara.asadmin}</executable>
+                                    <arguments>
+                                        <argument>create-system-property</argument>
+                                        <argument>log.file.location=${log.file.location}</argument>
                                     </arguments>
                                 </configuration>
                             </execution>

--- a/authorization-tck/payara-pom.xml
+++ b/authorization-tck/payara-pom.xml
@@ -184,11 +184,11 @@
                                 <configuration>
                                     <target>
                                         <exec executable="${payara.asadmin}">
-                                            <arg value="create-system-properties" />
+                                            <arg value="create-system-property" />
                                             <arg value="vendor.jakarta.security.jacc.PolicyConfigurationFactory.provider=org.glassfish.exousia.modules.def.DefaultPolicyConfigurationFactory" />
                                         </exec>
                                         <exec executable="${payara.asadmin}">
-                                            <arg value="create-system-properties" />
+                                            <arg value="create-system-property" />
                                             <arg value="log.file.location=${log.file.location}" />
                                         </exec>
                                         <exec executable="${payara.asadmin}">

--- a/bean-validation-tck/pom.xml
+++ b/bean-validation-tck/pom.xml
@@ -172,7 +172,7 @@
                         <configuration>
                             <executable>${payara.asadmin}</executable>
                             <arguments>
-                                <argument>create-system-properties</argument>
+                                <argument>create-system-property</argument>
                                 <argument>validation.provider=org.hibernate.validator.HibernateValidator</argument>
                             </arguments>
                         </configuration>

--- a/concurrent-tck/README.md
+++ b/concurrent-tck/README.md
@@ -13,10 +13,5 @@ If intending to run against a remote server (`-Ppayara-server-remote`), then you
 To skip server startup and shutdown, set `-DskipServerStartStop` to true. Defaults to true for remote profile, false otherwise.
 To skip server configuration, set to `-DskipConfig` to true. Defaults to false.
 
-If running on Windows, due to how the `create-system-properties` command parses ':' and '\' there is a property 
-provided for you to provide double-escapes via the CLI. 
-Example:
-`mvn clean verify -Ppayara-server-managed -Dpayara.version=... -Djiamge.dir.escaped=D\:\\Git\\JakartaEE10-TCK-Runners\\concurrent-tck\\target\\classes\\jimage -pl . -pl tck-download -pl tck-download/jakarta-concurrency-tck -pl concurrent-tck`
-
 To debug a single test, specify the name of the test using surefire syntax e.g. `-Dtest=SignatureTests#testSignatures`
 https://maven.apache.org/surefire/maven-surefire-plugin/examples/single-test.html

--- a/concurrent-tck/pom.xml
+++ b/concurrent-tck/pom.xml
@@ -62,8 +62,6 @@
 
 
         <jimage.dir>${project.build.outputDirectory}${file.separator}jimage</jimage.dir>
-        <!-- CLI override property workaround for Windows because of how the create-system-properties command parses ':' and '\' -->
-        <jimage.dir.escaped>${jimage.dir}</jimage.dir.escaped>
     </properties>
     
     <!-- The Arquillian test framework -->
@@ -197,7 +195,7 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>create-jvm-options</id>
+                        <id>create-jvm-option</id>
                         <phase>pre-integration-test</phase>
                         <goals>
                             <goal>exec</goal>
@@ -206,7 +204,7 @@
                             <skip>${skipConfig}</skip>
                             <executable>${payara.asadmin}</executable>
                             <arguments>
-                                <argument>create-jvm-options</argument>
+                                <argument>create-jvm-option</argument>
                                 <argument>--add-opens=java.base/jdk.internal.vm.annotation=ALL-UNNAMED</argument>
                             </arguments>
                         </configuration>
@@ -221,8 +219,8 @@
                             <skip>${skipConfig}</skip>
                             <executable>${payara.asadmin}</executable>
                             <arguments>
-                                <argument>create-system-properties</argument>
-                                <argument>jimage.dir=${jimage.dir.escaped}</argument>
+                                <argument>create-system-property</argument>
+                                <argument>jimage.dir=${jimage.dir}</argument>
                             </arguments>
                         </configuration>
                     </execution>

--- a/data-tck/pom.xml
+++ b/data-tck/pom.xml
@@ -148,7 +148,7 @@
                             <skip>${skipConfig}</skip>
                             <executable>${payara.asadmin}</executable>
                             <arguments>
-                                <argument>create-jvm-options</argument>
+                                <argument>create-jvm-option</argument>
                                 <argument>--add-opens=java.base/jdk.internal.vm.annotation=ALL-UNNAMED</argument>
                             </arguments>
                         </configuration>

--- a/jsonb-tck/pom.xml
+++ b/jsonb-tck/pom.xml
@@ -98,7 +98,7 @@
                         <configuration>
                             <target unless="${skipConfig}">
                                 <exec executable="${payara.asadmin}">
-                                    <arg value="create-jvm-options" />
+                                    <arg value="create-jvm-option" />
                                     <arg value="-Djava.locale.providers=COMPAT" />
                                 </exec>
                             </target>

--- a/tags-tck/pom.xml
+++ b/tags-tck/pom.xml
@@ -115,7 +115,7 @@
                         <configuration>
                             <executable>${payara.asadmin}</executable>
                             <arguments>
-                                <argument>create-jvm-options</argument>
+                                <argument>create-jvm-option</argument>
                                 <argument>-Djavax.xml.accessExternalStylesheet=all</argument>
                             </arguments>
                             <successCodes>
@@ -134,7 +134,7 @@
                         <configuration>
                             <executable>${payara.asadmin}</executable>
                             <arguments>
-                                <argument>create-jvm-options</argument>
+                                <argument>create-jvm-option</argument>
                                 <argument>-Djavax.xml.accessExternalSchema=all</argument>
                             </arguments>
                             <successCodes>
@@ -153,7 +153,7 @@
                         <configuration>
                             <executable>${payara.asadmin}</executable>
                             <arguments>
-                                <argument>create-jvm-options</argument>
+                                <argument>create-jvm-option</argument>
                                 <argument>-Djavax.xml.accessExternalDTD=file,http</argument>
                             </arguments>
                             <successCodes>

--- a/xml-ws-tck/run-tck.sh
+++ b/xml-ws-tck/run-tck.sh
@@ -22,10 +22,10 @@ echo "Starting Payara for setup"
 echo "Setting file user javajoe"
 ./asadmin --passwordfile=prepare-server-password create-file-user --groups=Manager --authrealmname=file javajoe
 echo "Setting system property jimage.dir", needed for SignatureTestServlet
-./asadmin create-system-properties jimage.dir=/tmp
+./asadmin create-system-property jimage.dir=/tmp
 echo "Setting allow setAccessible, needed for SignatureTestServlet"
-./asadmin create-jvm-options "--add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED"
-./asadmin create-jvm-options "--add-opens=java.base/jdk.internal.vm.annotation=ALL-UNNAMED"
+./asadmin create-jvm-option "--add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED"
+./asadmin create-jvm-option "--add-opens=java.base/jdk.internal.vm.annotation=ALL-UNNAMED"
 echo "Setup phase done, stopping Payara"
 ./asadmin stop-domain
 popd


### PR DESCRIPTION
Use the singular create-system-property and create-jvm-option commands where appropriate, since the asadmin : separator doesn't play well with Windows paths.

Tested here: https://jenkins.payara.fish/job/JakartaEE-11-TCK/128/

Requires https://github.com/payara/Payara/pull/7195