### PR TITLE
Fish 10181 fix html unit cce

### DIFF
--- a/security-tck/payara-profile.xml
+++ b/security-tck/payara-profile.xml
@@ -637,7 +637,7 @@
             
             <properties>
                 <payara.root>${maven.multiModuleProjectDirectory}/target</payara.root>
-                <payara.version>7.2024.1.Alpha3-SNAPSHOT</payara.version>
+                <payara.version>7.2025.1.Alpha1-SNAPSHOT</payara.version>
                 <payara.arquillian.container.version>4.0.alpha2</payara.arquillian.container.version>
                 <payara.artifact>payara</payara.artifact>
                 

--- a/security-tck/run-tck.sh
+++ b/security-tck/run-tck.sh
@@ -8,6 +8,7 @@ mkdir target
 wget -q https://download.eclipse.org/jakartaee/security/4.0/jakarta-security-tck-4.0.0.zip -O target/jakarta-security-tck-4.0.0.zip
 unzip -q target/jakarta-security-tck-4.0.0.zip -d target
 sed -i 's/\${glassfish.root}\/glassfish8/\${payara.root}\/payara7/g' target/security-tck-4.0.0/tck/**/pom.xml
+sed -i 's/cacerts.jks/cacerts.p12/g' target/security-tck-4.0.0/tck/**/pom.xml
 cp -f payara-profile.xml target/security-tck-4.0.0/tck/pom.xml
 cp -f old-tck-run-payara.xml target/security-tck-4.0.0/tck/old-tck/run/pom.xml
 

--- a/security-tck/run-tck.sh
+++ b/security-tck/run-tck.sh
@@ -8,6 +8,7 @@ mkdir target
 wget -q https://download.eclipse.org/jakartaee/security/4.0/jakarta-security-tck-4.0.0.zip -O target/jakarta-security-tck-4.0.0.zip
 unzip -q target/jakarta-security-tck-4.0.0.zip -d target
 sed -i 's/\${glassfish.root}\/glassfish8/\${payara.root}\/payara7/g' target/security-tck-4.0.0/tck/**/pom.xml
+sed -i 's#<javax.net.ssl.trustStore>\${payara.root}/payara7/glassfish/domains/domain1/config/cacerts.jks</javax.net.ssl.trustStore>#<javax.net.ssl.trustStore>\${payara.root}/payara7/glassfish/domains/domain1/config/cacerts.p12</javax.net.ssl.trustStore>\n<javax.net.ssl.trustStorePassword>changeit</javax.net.ssl.trustStorePassword>\n<javax.net.ssl.trustStoreType>PKCS12</javax.net.ssl.trustStoreType>#g' target/security-tck-4.0.0/tck/**/pom.xml
 sed -i 's/cacerts.jks/cacerts.p12/g' target/security-tck-4.0.0/tck/**/pom.xml
 cp -f payara-profile.xml target/security-tck-4.0.0/tck/pom.xml
 cp -f old-tck-run-payara.xml target/security-tck-4.0.0/tck/old-tck/run/pom.xml

--- a/security-tck/run-tck.sh
+++ b/security-tck/run-tck.sh
@@ -10,6 +10,7 @@ unzip -q target/jakarta-security-tck-4.0.0.zip -d target
 sed -i 's/\${glassfish.root}\/glassfish8/\${payara.root}\/payara7/g' target/security-tck-4.0.0/tck/**/pom.xml
 sed -i 's#<javax.net.ssl.trustStore>\${payara.root}/payara7/glassfish/domains/domain1/config/cacerts.jks</javax.net.ssl.trustStore>#<javax.net.ssl.trustStore>\${payara.root}/payara7/glassfish/domains/domain1/config/cacerts.p12</javax.net.ssl.trustStore>\n<javax.net.ssl.trustStorePassword>changeit</javax.net.ssl.trustStorePassword>\n<javax.net.ssl.trustStoreType>PKCS12</javax.net.ssl.trustStoreType>#g' target/security-tck-4.0.0/tck/**/pom.xml
 sed -i 's/cacerts.jks/cacerts.p12/g' target/security-tck-4.0.0/tck/**/pom.xml
+sed -i 's/<alias>tomcat<\/alias>/<alias>tomcat-openid3<\/alias>/g' target/security-tck-4.0.0/tck/app-openid3/pom.xml
 cp -f payara-profile.xml target/security-tck-4.0.0/tck/pom.xml
 cp -f old-tck-run-payara.xml target/security-tck-4.0.0/tck/old-tck/run/pom.xml
 


### PR DESCRIPTION
This change makes it possible no run modules  app-openid2 and app-openid3 without errors regarding certificates and truststores.