### PR TITLE
Fix commons codec issue

### DIFF
--- a/jsonb-platform-tck/pom.xml
+++ b/jsonb-platform-tck/pom.xml
@@ -112,6 +112,13 @@
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Required by jenkins due to varying transitive versions of this dependency -->
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${commons-codec.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/jsonp-platform-tck/pom.xml
+++ b/jsonp-platform-tck/pom.xml
@@ -119,6 +119,13 @@
             <artifactId>arquillian-junit5-container</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Required by jenkins due to varying transitive versions of this dependency -->
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${commons-codec.version}</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Caused issues when running in Jenkins due to maven picking up the wrong commons codec version provided transitively 

https://jenkins.payara.fish/blue/organizations/jenkins/JakartaEE-11-TCK/detail/JakartaEE-11-TCK/174/pipeline/