### PR TITLE
FISH-10948 FISH-10945 FISH-10943 FISH-10944 Resolve Rest Platform ser…

### DIFF
--- a/ejb-platform-tck/pom.xml
+++ b/ejb-platform-tck/pom.xml
@@ -164,6 +164,11 @@
             <version>3.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${commons-codec.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/ejb-platform-tck/pom.xml
+++ b/ejb-platform-tck/pom.xml
@@ -330,6 +330,21 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>disable-substitution</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipConfig}</skip>
+                            <executable>${payara.asadmin}</executable>
+                            <arguments>
+                                <argument>create-jvm-option</argument>
+                                <argument>-Dfish.payara.substitution.disable=true</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>create-derby-xa-pool</id>
                         <phase>pre-integration-test</phase>
                         <goals>

--- a/rest-platform-tck/pom.xml
+++ b/rest-platform-tck/pom.xml
@@ -11,12 +11,6 @@
 
     <artifactId>rest-platform-tck</artifactId>
 
-    <properties>
-        <jakarta.ws.rs-api.version>4.0.0</jakarta.ws.rs-api.version>
-        <jersey.version>4.0.0-M2</jersey.version>
-        <yasson.version>3.0.4</yasson.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>jakarta.tck</groupId>
@@ -29,27 +23,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>jakarta.ws.rs</groupId>
-            <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>${jakarta.ws.rs-api.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse</groupId>
-            <artifactId>yasson</artifactId>
-            <version>${yasson.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-client</artifactId>
-            <version>${jersey.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-json-jackson</artifactId>
-            <version>${jersey.version}</version>
-            <scope>provided</scope>
+            <groupId>fish.payara.arquillian</groupId>
+            <artifactId>payara-client-ee11</artifactId>
+            <version>${payara.arquillian.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
…verJsonStringArgumentTest and EJB web.xml expansion

Cleaned up dependencies for rest platform tck and added required payara-client-ee11

Disabled substitution for ejb platform tck - this was done in EE 10 as well

See https://jenkins.payara.fish/job/JakartaEE-11-TCK/180/ and https://jenkins.payara.fish/view/TCKs/job/JakartaEE-11-TCK/181/

Server log collection is fixed here (https://github.com/payara/EngineeringJenkinsjobs/pull/249)