### PR TITLE
FISH-11048: Batch TCK on JDK17

### DIFF
--- a/batch-tck/sigtests/pom.xml
+++ b/batch-tck/sigtests/pom.xml
@@ -72,6 +72,7 @@
                     <plugin>
                         <groupId>org.netbeans.tools</groupId>
                         <artifactId>sigtest-maven-plugin</artifactId>
+                        <version>1.6</version>
                         <executions>
                             <execution>
                                 <id>sigtest</id>
@@ -102,6 +103,7 @@
                     <plugin>
                         <groupId>jakarta.tck</groupId>
                         <artifactId>sigtest-maven-plugin</artifactId>
+                        <version>2.6</version>
                         <executions>
                             <execution>
                                 <id>sigtest</id>


### PR DESCRIPTION
Changes the batch TCK to use the more recent sigtest plugin when run on JDK17.

Build passes all tests locally, [and on Jenkins](https://jenkins.payara.fish/view/TCKs/job/JakartaEE-10-TCK/573/).