### PR TITLE
FISH-10840 Fix Mail TCK 

### DIFF
--- a/mail-platform-tck/pom.xml
+++ b/mail-platform-tck/pom.xml
@@ -130,7 +130,6 @@
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>arquillian-protocol-lib</artifactId>
-            <version>${jakarta.tck.arquillian.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
@@ -195,18 +194,11 @@
                                     <destFileName>arquillian-protocol-lib.jar</destFileName>
                                 </artifactItem>
                                 <artifactItem>
-                                    <groupId>jakarta.tck</groupId>
-                                    <artifactId>common</artifactId>
-                                    <overWrite>true</overWrite>
-                                    <outputDirectory>${payara.home}${file.separator}glassfish${file.separator}lib</outputDirectory>
-                                    <destFileName>common.jar</destFileName>
-                                </artifactItem>
-                                <artifactItem>
                                     <groupId>jakarta.tck.arquillian</groupId>
-                                    <artifactId>tck-porting-lib</artifactId>
+                                    <artifactId>arquillian-protocol-lib</artifactId>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${payara.home}${file.separator}glassfish${file.separator}lib</outputDirectory>
-                                    <destFileName>tck-porting-lib.jar</destFileName>
+                                    <outputDirectory>${project.build.directory}/protocol</outputDirectory>
+                                    <destFileName>protocol.jar</destFileName>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>
@@ -270,7 +262,7 @@
                         </goals>
                         <phase>pre-integration-test</phase>
                         <configuration>
-                            <skip>${skipTests}</skip>
+                            <skip>${skipServerStartStop}</skip>
                             <executable>${payara.asadmin}</executable>
                             <arguments>
                                 <argument>start-domain</argument>
@@ -312,7 +304,7 @@
                         </goals>
                         <phase>pre-integration-test</phase>
                         <configuration>
-                            <skip>${skipTests}</skip>
+                            <skip>${skipConfig}</skip>
                             <executable>${payara.asadmin}</executable>
                             <arguments>
                                 <argument>create-javamail-resource</argument>
@@ -335,7 +327,7 @@
                         </goals>
                         <phase>pre-integration-test</phase>
                         <configuration>
-                            <skip>${skipTests}</skip>
+                            <skip>${skipServerStartStop}</skip>
                             <executable>${payara.asadmin}</executable>
                             <arguments>
                                 <argument>stop-domain</argument>


### PR DESCRIPTION
Resyncs some config with the Platform TCK WRT to which libraries are required.

Also includes some misc little fixes to the runner itself (e.g. `skipConfig` instead of `skipTests`).

Tested here: https://jenkins.payara.fish/blue/organizations/jenkins/JakartaEE-11-TCK/detail/JakartaEE-11-TCK/227/pipeline

Missing server log collection will be addressed in another PR