### PR TITLE
FISH-10957 Fix Persistence TCK Appclient Deployment Failures

### DIFF
--- a/persistence-platform-tck/pom.xml
+++ b/persistence-platform-tck/pom.xml
@@ -17,39 +17,27 @@
     </properties>
 
     <!-- Something in this BOM causes Junit to find no tests - this should be addressed -->
-<!--    <dependencyManagement>-->
-<!--        <dependencies>-->
-<!--            <dependency>-->
-<!--                <groupId>fish.payara.api</groupId>-->
-<!--                <artifactId>payara-bom</artifactId>-->
-<!--                <version>${payara.version}</version>-->
-<!--                <type>pom</type>-->
-<!--                <scope>import</scope>-->
-<!--            </dependency>-->
-<!--        </dependencies>-->
-<!--    </dependencyManagement>-->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>fish.payara.api</groupId>
+                <artifactId>payara-bom</artifactId>
+                <version>${payara.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
-        <!-- Jakarta EE dependencies -->
-        <dependency>
-            <groupId>jakarta.platform</groupId>
-            <artifactId>jakarta.jakartaee-api</artifactId>
-            <!-- Version should be provided by payara-bom - needs fixing -->
-            <version>11.0.0-RC1</version>
-            <scope>provided</scope>
-        </dependency>
         <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
-            <!-- Version should be provided by payara-bom - needs fixing -->
-            <version>2.0.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
-            <!-- Version should be provided by payara-bom - needs fixing -->
-            <version>3.2.0</version>
         </dependency>
 
         <!-- The TCK itself -->
@@ -89,19 +77,19 @@
             <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>
             <version>${jakarta.tck.common.version}</version>
-            <!-- Jenkins seems to require us to require us to not use the version bundled with this (1.2) -->
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-codec</groupId>
-                    <artifactId>commons-codec</artifactId>
-                </exclusion>
-            </exclusions>
+<!--            &lt;!&ndash; Jenkins seems to require us to require us to not use the version bundled with this (1.2) &ndash;&gt;-->
+<!--            <exclusions>-->
+<!--                <exclusion>-->
+<!--                    <groupId>commons-codec</groupId>-->
+<!--                    <artifactId>commons-codec</artifactId>-->
+<!--                </exclusion>-->
+<!--            </exclusions>-->
         </dependency>
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>${commons-codec.version}</version>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>commons-codec</groupId>-->
+<!--            <artifactId>commons-codec</artifactId>-->
+<!--            <version>${commons-codec.version}</version>-->
+<!--        </dependency>-->
 
         <!-- Junit -->
         <dependency>
@@ -150,23 +138,6 @@
             <artifactId>payara-client-ee11</artifactId>
             <version>${payara.arquillian.version}</version>
             <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.shrinkwrap.resolver</groupId>
-            <artifactId>shrinkwrap-resolver-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.shrinkwrap.resolver</groupId>
-            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.shrinkwrap.resolver</groupId>
-            <artifactId>shrinkwrap-resolver-api-maven</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.shrinkwrap.resolver</groupId>
-            <artifactId>shrinkwrap-resolver-spi-maven</artifactId>
         </dependency>
 
         <!-- Arquillian extensions for TCK  -->

--- a/persistence-platform-tck/pom.xml
+++ b/persistence-platform-tck/pom.xml
@@ -482,7 +482,6 @@
 
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-
                 <executions>
                     <execution>
                         <id>jpa-tests-javatest</id>
@@ -556,87 +555,6 @@
                     <version>${jakarta.tck.arquillian.version}</version>
                 </dependency>
             </dependencies>
-
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>copy-tck-common</id>
-                                <goals>
-                                    <goal>copy</goal>
-                                </goals>
-                                <phase>generate-resources</phase>
-                                <configuration>
-                                    <artifactItems>
-                                        <artifactItem>
-                                            <groupId>jakarta.tck</groupId>
-                                            <artifactId>common</artifactId>
-                                            <overWrite>true</overWrite>
-                                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                                            <destFileName>common.jar</destFileName>
-                                        </artifactItem>
-                                        <artifactItem>
-                                            <groupId>jakarta.tck.arquillian</groupId>
-                                            <artifactId>tck-porting-lib</artifactId>
-                                            <overWrite>true</overWrite>
-                                            <outputDirectory>${project.build.directory}${file.separator}lib</outputDirectory>
-                                            <destFileName>tck-porting-lib.jar</destFileName>
-                                        </artifactItem>
-                                        <artifactItem>
-                                            <groupId>jakarta.tck.arquillian</groupId>
-                                            <artifactId>arquillian-protocol-lib</artifactId>
-                                            <overWrite>true</overWrite>
-                                            <outputDirectory>${project.build.directory}${file.separator}lib</outputDirectory>
-                                            <destFileName>arquillian-protocol-lib.jar</destFileName>
-                                        </artifactItem>
-                                        <artifactItem>
-                                            <groupId>jakarta.tck.arquillian</groupId>
-                                            <artifactId>arquillian-protocol-appclient</artifactId>
-                                            <overWrite>true</overWrite>
-                                            <outputDirectory>${project.build.directory}${file.separator}lib</outputDirectory>
-                                            <destFileName>arquillian-protocol-appclient.jar</destFileName>
-                                        </artifactItem>
-                                        <!-- TODO - verify if these are necessary -->
-                                        <artifactItem>
-                                            <groupId>jakarta.tck</groupId>
-                                            <artifactId>persistence-platform-tck-common</artifactId>
-                                            <overWrite>true</overWrite>
-                                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                                            <destFileName>persistence-platform-tck-common.jar</destFileName>
-                                        </artifactItem>
-                                        <artifactItem>
-                                            <groupId>jakarta.tck</groupId>
-                                            <artifactId>persistence-platform-tck-spec-tests</artifactId>
-                                            <overWrite>true</overWrite>
-                                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                                            <destFileName>persistence-platform-tck-spec-tests.jar</destFileName>
-                                        </artifactItem>
-                                        <artifactItem>
-                                            <groupId>jakarta.tck</groupId>
-                                            <artifactId>persistence-platform-tck-tests</artifactId>
-                                            <overWrite>true</overWrite>
-                                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                                            <destFileName>persistence-platform-tck-tests.jar</destFileName>
-                                        </artifactItem>
-                                        <artifactItem>
-                                            <groupId>jakarta.tck</groupId>
-                                            <artifactId>persistence-platform-tck-dbprocedures</artifactId>
-                                            <overWrite>true</overWrite>
-                                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                                            <destFileName>persistence-platform-tck-dbprocedures.jar</destFileName>
-                                        </artifactItem>
-                                    </artifactItems>
-                                </configuration>
-                            </execution>
-
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-
-
         </profile>
     </profiles>
 

--- a/persistence-platform-tck/pom.xml
+++ b/persistence-platform-tck/pom.xml
@@ -77,19 +77,19 @@
             <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>
             <version>${jakarta.tck.common.version}</version>
-<!--            &lt;!&ndash; Jenkins seems to require us to require us to not use the version bundled with this (1.2) &ndash;&gt;-->
-<!--            <exclusions>-->
-<!--                <exclusion>-->
-<!--                    <groupId>commons-codec</groupId>-->
-<!--                    <artifactId>commons-codec</artifactId>-->
-<!--                </exclusion>-->
-<!--            </exclusions>-->
+            <!-- Jenkins seems to require us to require us to not use the version bundled with this (1.2) -->
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>commons-codec</groupId>-->
-<!--            <artifactId>commons-codec</artifactId>-->
-<!--            <version>${commons-codec.version}</version>-->
-<!--        </dependency>-->
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${commons-codec.version}</version>
+        </dependency>
 
         <!-- Junit -->
         <dependency>

--- a/persistence-platform-tck/src/test/resources/arquillian.xml
+++ b/persistence-platform-tck/src/test/resources/arquillian.xml
@@ -77,6 +77,7 @@
                     ${deploymentName} \
                     target
                 </property>
+                <property name="clientStubsJarSuffix">Client</property>
                 <property name="workDir">${ts.work.dir}/tmp</property>
                 <property name="tsJteFile">jakartaeetck/bin/ts.jte</property>
                 <property name="tsSqlStmtFile">sql/derby/derby.dml.sql</property>

--- a/persistence-platform-tck/src/test/resources/arquillian.xml
+++ b/persistence-platform-tck/src/test/resources/arquillian.xml
@@ -43,45 +43,41 @@
                 <property name="clientEarDir">target/appclient</property>
                 <property name="unpackClientEar">true</property>
                 <!-- Need to populate from ts.jte command.testExecuteAppClient setting for glassfish -->
-                <property name="clientCmdLineString">${payara.home}/glassfish/bin/appclient \
-                    -Djdk.tls.client.enableSessionTicketExtension=false \
-                    -Djdk.tls.server.enableSessionTicketExtension=false \
-                    -Djava.security.policy=${payara.home}/glassfish/lib/appclient/client.policy \
+                <property name="clientCmdLineString">${env.JAVA_HOME}/bin/java \
+                    --add-opens \
+                    java.base/java.lang=ALL-UNNAMED \
+                    -cp \
+                    ${payara.home}/glassfish/lib/gf-client.jar:${clientStubJar} \
+                    -Djava.system.class.loader=org.glassfish.appclient.client.acc.agent.ACCAgentClassLoader \
+                    -Dcom.sun.aas.configRoot=${payara.home}/glassfish/config \
                     -Dcts.tmp=${ts.work.dir}/tmp \
-                    -Djava.security.auth.login.config=${payara.home}/glassfish/lib/appclient/appclientlogin.conf \
-                    -Djava.protocol.handler.pkgs=javax.net.ssl \
-                    -Djavax.net.ssl.keyStore=${ts.home}/bin/certificates/clientcert.p12 \
-                    -Djavax.net.ssl.keyStorePassword=changeit \
-                    -Djavax.net.ssl.trustStore=${payara.home}/glassfish/domains/domain1/config/cacerts.p12 \
-                    -Djavax.xml.parsers.SAXParserFactory=com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl \
-                    -Djavax.xml.parsers.DocumentBuilderFactory=com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl
-                    \
-                    -Djavax.xml.transform.TransformerFactory=com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl
-                    \
-                    -Dorg.xml.sax.driver=com.sun.org.apache.xerces.internal.parsers.SAXParser \
-                    -Dorg.xml.sax.parser=org.xml.sax.helpers.XMLReaderAdapter \
                     -Doracle.jdbc.J2EE13Compliant=true \
                     -Doracle.jdbc.mapDateToTimestamp \
-                    -Dstartup.login=false \
-                    -Dauth.gui=false \
                     -Dlog.file.location=${payara.home}/glassfish/domains/domain1/logs \
                     -Dri.log.file.location=${payara.home}/glassfish/domains/domain1/logs \
                     -DwebServerHost.2=localhost \
                     -DwebServerPort.2=8080 \
-                    -Ddeliverable.class=com.sun.ts.lib.deliverable.cts.CTSDeliverable \
-                    -jar \
-                    ${clientEarDir}/${clientAppArchive}
+                    -javaagent:${payara.home}/glassfish/lib/gf-client.jar=arg=-configxml,arg=${payara.home}/glassfish/domains/domain1/config/glassfish-acc.xml,client=jar=${clientStubJar},arg=-name,arg=${clientAppArchiveName} \
+                    org.glassfish.appclient.client.AppClientGroupFacade
                 </property>
                 <property name="cmdLineArgSeparator">\\</property>
                 <!-- Pass ENV vars here -->
                 <!-- <property name="clientEnvString">PATH=${env.PATH};LD_LIBRARY_PATH=${payara.home}/lib;AS_DEBUG=true;
                     APPCPATH=${payara.home}/glassfish/lib/arquillian-protocol-lib.jar:${payara.home}/glassfish/lib/tck-porting-lib.jar:target/appclient/lib/arquillian-core.jar:target/appclient/lib/arquillian-junit5.jar:${payara.home}/glassfish/modules/security.jar</property> -->
                 <property name="clientEnvString">
-                    AS_JAVA=${env.JAVA_HOME};PATH=${env.PATH};LD_LIBRARY_PATH=${payara.home}/lib;AS_DEBUG=true;
-                    APPCPATH=target/appclient/lib/arquillian-protocol-lib.jar${path.separator}target/lib/common.jar${path.separator}target/lib/tck-porting-lib.jar${path.separator}target/appclient/lib/arquillian-core.jar${path.separator}target/appclient/lib/arquillian-junit5.jar${path.separator}${payara.home}/glassfish/modules/security.jar${path.separator}${payara.home}/glassfish/lib/gf-client.jar
+                    PATH=${env.PATH};LD_LIBRARY_PATH=${payara.home}/lib;AS_DEBUG=true;
+                    APPCPATH=${clientEarLibClasspath}:${payara.home}/glassfish/modules/security.jar
                 </property>
                 <property name="clientDir">${project.basedir}</property>
-                <property name="workDir">${ts.work.dir}</property>
+                <property name="clientStubsCmdLine">${env.JAVA_HOME}/bin/java \
+                    -jar \
+                    ${payara.home}/glassfish/modules/admin-cli.jar \
+                    get-client-stubs \
+                    --appName \
+                    ${deploymentName} \
+                    target
+                </property>
+                <property name="workDir">${ts.work.dir}/tmp</property>
                 <property name="tsJteFile">jakartaeetck/bin/ts.jte</property>
                 <property name="tsSqlStmtFile">sql/derby/derby.dml.sql</property>
                 <property name="trace">true</property>


### PR DESCRIPTION
Fixes the deployment failures we were getting with the appclient tests.
Doesn't fully fix the TCK (yet), we're still getting failures on:

* ee.jakarta.tck.persistence.ee.cdi.ServletEMLookupTest
* ee.jakarta.tck.persistence.ee.packaging.appclient.annotation.ClientTest
* ee.jakarta.tck.persistence.ee.packaging.appclient.descriptor.ClientTest

Test running here: https://jenkins.payara.fish/view/Development%20Testing/job/JakartaEE-11-TCK-FISH-10957-Persistence-Platform-Development/

Counterpart to https://github.com/payara/EngineeringJenkinsjobs/pull/292