### PR TITLE
FISH-10490 Add MVC 2.1 TCK Runner

### DIFF
--- a/mvc-tck/README.md
+++ b/mvc-tck/README.md
@@ -1,0 +1,17 @@
+# Jakarta MVC TCK Runner
+
+## Prerequisite
+
+Download and install the TCK into your local Maven repo. 
+From the top-level directory: `mvn clean install -pl . -pl tck-download -pl tck-download/jakarta-mvc-tck`
+
+## Test Execution
+
+To execute the full TCK against a managed Payara Server, execute from the top-level directory.
+
+```
+mvn clean verify -pl . -pl mvc-tck -Ppayara-server-managed
+```
+
+Remote profile is also supported, and can be run directly from the `mvc-tck` directory.
+The TCK does not require any server-side configuration.

--- a/mvc-tck/pom.xml
+++ b/mvc-tck/pom.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>fish.payara.jakarta.tests.tck</groupId>
+        <artifactId>tck</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>mvc-tck-runner</artifactId>
+
+    <name>TCK: MVC</name>
+
+    <properties>
+        <tck.home>${project.build.directory}/authorization-tck</tck.home>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>fish.payara.api</groupId>
+                <artifactId>payara-bom</artifactId>
+                <version>${payara.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <!-- Used by archive provider to lookup versions -->
+            <dependency>
+                <groupId>org.eclipse.krazo</groupId>
+                <artifactId>krazo-core</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.krazo</groupId>
+                <artifactId>krazo-jersey</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.krazo</groupId>
+                <artifactId>krazo-resteasy</artifactId>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.mvc.tck</groupId>
+            <artifactId>mvc-tck-api</artifactId>
+            <version>${jakarta.tck.mvc.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.mvc.tck</groupId>
+            <artifactId>mvc-tck-tests</artifactId>
+            <version>${jakarta.tck.mvc.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <!-- The TCK bundles junit 4 which transitively utilises a newer version of hamcrest -->
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-depchain</artifactId>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- The TCK is compiled against a specific version of hamcrest and won't work with newer versions -->
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-install</id>
+                        <phase>disabled</phase>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>run-tests</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <dependenciesToScan>jakarta.mvc.tck:mvc-tck-tests</dependenciesToScan>
+                            <includes>
+                                <include>*</include>
+                            </includes>
+                            <systemPropertyVariables>
+                                <arquillian.launch>payara</arquillian.launch>
+                                <ee.jakarta.tck.mvc.api.BaseArchiveProvider>org.eclipse.krazo.tck.payara.PayaraModuleArchiveProvider</ee.jakarta.tck.mvc.api.BaseArchiveProvider>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/mvc-tck/src/test/java/org/eclipse/krazo/tck/payara/PayaraModuleArchiveProvider.java
+++ b/mvc-tck/src/test/java/org/eclipse/krazo/tck/payara/PayaraModuleArchiveProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021, 2025 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.krazo.tck.payara;
+
+import ee.jakarta.tck.mvc.api.BaseArchiveProvider;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+/**
+ * BaseArchiveProvider implementation for running TCK against Payara
+ */
+public class PayaraModuleArchiveProvider implements BaseArchiveProvider {
+
+    @Override
+    public WebArchive getBaseArchive() {
+        return ShrinkWrap.create(WebArchive.class);
+    }
+
+}

--- a/mvc-tck/src/test/resources/arquillian.xml
+++ b/mvc-tck/src/test/resources/arquillian.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+
+    Copyright (c) 2018, 2025 Eclipse Krazo committers and contributors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    SPDX-License-Identifier: Apache-2.0
+
+-->
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://jboss.org/schema/arquillian"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <!--
+        Unpack archives to this directory for easier debugging
+    -->
+    <engine>
+        <property name="deploymentExportPath">target/deployments</property>
+    </engine>
+
+    <container qualifier="payara">
+        <configuration>
+            <property name="adminHost">localhost</property>
+            <property name="adminPort">4848</property>
+        </configuration>
+    </container>
+
+</arquillian>

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,7 @@
         <jakarta.tck.batch.version>2.1.5</jakarta.tck.batch.version>
         <jakarta.tck.core-profile.version>10.0.3</jakarta.tck.core-profile.version>
         <jakarta.tck.inject.version>2.0.2</jakarta.tck.inject.version>
+        <jakarta.tck.mvc.version>2.1.0</jakarta.tck.mvc.version>
         
         <!-- The profile to run - acceptable parameters are 'full', 'web', and 'core' -->
         <jakarta.tck.platform>full</jakarta.tck.platform>
@@ -134,6 +135,7 @@
         <module>inject-tck</module>
         <module>jsonb-tck</module>
         <module>jsonp-tck</module>
+        <module>mvc-tck</module>
         <module>pages-tck</module>
         <module>rest-tck</module>
         <module>servlet-tck</module>
@@ -380,6 +382,23 @@
                                 </configuration>
                             </execution>
                         </executions>
+                    </plugin>
+
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <payara.home>${payara.home}</payara.home>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <payara.home>${payara.home}</payara.home>
+                            </systemPropertyVariables>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/tck-download/jakarta-mvc-tck/pom.xml
+++ b/tck-download/jakarta-mvc-tck/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>fish.payara.jakarta.tests.tck</groupId>
+        <artifactId>tck-download</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jakarta-mvc-tck</artifactId>
+    <packaging>pom</packaging>
+
+    <name>TCK: Install Jakarta mvc TCK</name>
+
+    <properties>
+        <tck.test.mvc.file>jakarta-mvc-tck-${jakarta.tck.mvc.version}.zip</tck.test.mvc.file>
+        <tck.tests.mvc.url>https://download.eclipse.org/jakartaee/mvc/2.1/${tck.test.mvc.file}</tck.tests.mvc.url>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <artifactId>download-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>download-mvc-tck</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>${tck.tests.mvc.url}</url>
+                            <unpack>true</unpack>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-install-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>install-mvc-tck-tests</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                        <configuration>
+                            <file>${project.build.directory}${file.separator}mvc-tck-dist-${jakarta.tck.mvc.version}${file.separator}artifacts${file.separator}mvc-tck-tests-${jakarta.tck.mvc.version}.jar</file>
+                            <groupId>jakarta.mvc.tck</groupId>
+                            <artifactId>mvc-tck-tests</artifactId>
+                            <version>${jakarta.tck.mvc.version}</version>
+                            <packaging>jar</packaging>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>install-mvc-tck-api</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                        <configuration>
+                            <file>${project.build.directory}${file.separator}mvc-tck-dist-${jakarta.tck.mvc.version}${file.separator}lib${file.separator}mvc-tck-api-${jakarta.tck.mvc.version}.jar</file>
+                            <groupId>jakarta.mvc.tck</groupId>
+                            <artifactId>mvc-tck-api</artifactId>
+                            <version>${jakarta.tck.mvc.version}</version>
+                            <packaging>jar</packaging>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tck-download/pom.xml
+++ b/tck-download/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation. All rights reserved.
+    Copyright (c) 2021, 2025 Contributors to the Eclipse Foundation. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -45,6 +45,7 @@
         <module>jakarta-concurrency-tck</module>
         <module>jakarta-core-profile-tck</module>
         <module>jakarta-inject-tck</module>
+        <module>jakarta-mvc-tck</module>
     </modules>
 
     <build>


### PR DESCRIPTION
Adds a TCK runner for MVC 2.1

Counterpart to https://github.com/payara/EngineeringJenkinsjobs/pull/332

Tested here: 
* [Platform](https://jenkins.payara.fish/view/Development%20Testing/job/Development-FISH-10490-MVC-TCK-Runner/4/)
* [Web Profile](https://jenkins.payara.fish/view/Development%20Testing/job/Development-FISH-10490-MVC-TCK-Runner/5/)