### PR TITLE
FISH-12882 : Add Jakarta Agentic AI TCK runner module with download, …

### DIFF
--- a/agentic-ai-tck/pom.xml
+++ b/agentic-ai-tck/pom.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+  Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+
+  The contents of this file are subject to the terms of either the GNU
+  General Public License Version 2 only ("GPL") or the Common Development
+  and Distribution License("CDDL") (collectively, the "License").  You
+  may not use this file except in compliance with the License.  You can
+  obtain a copy of the License at
+  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  See the License for the specific
+  language governing permissions and limitations under the License.
+
+  When distributing the software, include this License Header Notice in each
+  file and include the License file at glassfish/legal/LICENSE.txt.
+
+  GPL Classpath Exception:
+  The Payara Foundation designates this particular file as subject to the "Classpath"
+  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  file that accompanied this code.
+
+  Modifications:
+  If applicable, add the following below the License Header, with the fields
+  enclosed by brackets [] replaced by your own identifying information:
+  "Portions Copyright [year] [name of copyright owner]"
+
+  Contributor(s):
+  If you wish your version of this file to be governed by only the CDDL or
+  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  elects to include this software in this distribution under the [CDDL or GPL
+  Version 2] license."  If you don't indicate a single choice of license, a
+  recipient has the option to distribute your version of this file under
+  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  its licensees as provided above.  However, if you add GPL Version 2 code
+  and therefore, elected the GPL Version 2 license, then the option applies
+  only if the new code is made subject to such option by the copyright
+  holder.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>fish.payara.jakarta.tests.tck</groupId>
+        <artifactId>tck</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>agentic-ai-tck-runner</artifactId>
+
+    <name>TCK: Agentic AI</name>
+    <packaging>jar</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>fish.payara.api</groupId>
+                <artifactId>payara-bom</artifactId>
+                <version>${payara.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.ai</groupId>
+            <artifactId>jakarta-agentic-ai-tck</artifactId>
+            <version>${jakarta.tck.agentic-ai.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ai</groupId>
+            <artifactId>jakarta.agentic-ai-api</artifactId>
+            <version>${jakarta.tck.agentic-ai.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-container</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.tck</groupId>
+            <artifactId>sigtest-maven-plugin</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>run-agentic-ai-tck</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <dependenciesToScan>jakarta.ai:jakarta-agentic-ai-tck</dependenciesToScan>
+                            <includes>
+                                <include>*</include>
+                            </includes>
+                            <systemPropertyVariables>
+                                <payara.home>${payara.home}</payara.home>
+                                <jimage.dir>${jimage.dir}</jimage.dir>
+                                <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
+                                <signature.sigTestClasspath>${payara.home}${file.separator}glassfish${file.separator}modules${file.separator}jakarta.agentic-ai-api.jar${path.separator}${project.build.directory}${file.separator}jdk-bundle${file.separator}java.base${path.separator}${project.build.directory}${file.separator}jdk-bundle${file.separator}java.rmi${path.separator}${project.build.directory}${file.separator}jdk-bundle${file.separator}java.sql${path.separator}${project.build.directory}${file.separator}jdk-bundle${file.separator}java.naming</signature.sigTestClasspath>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>payara-server-remote</id>
+            <properties>
+                <skipConfig>true</skipConfig>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/agentic-ai-tck/src/test/resources/arquillian.xml
+++ b/agentic-ai-tck/src/test/resources/arquillian.xml
@@ -1,0 +1,17 @@
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://jboss.org/schema/arquillian"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian  https://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <defaultProtocol type="Servlet 6.0"/>
+
+    <container qualifier="payara-remote" default="true">
+        <configuration>
+            <property name="adminHost">localhost</property>
+            <property name="adminPort">4848</property>
+            <property name="adminUser">admin</property>
+            <property name="adminPassword"></property>
+            <property name="target">server</property>
+        </configuration>
+    </container>
+
+</arquillian>

--- a/agentic-ai-tck/src/test/resources/beans.xml
+++ b/agentic-ai-tck/src/test/resources/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_1.xsd"
+       bean-discovery-mode="annotated">
+</beans>

--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,7 @@
         <jakarta.tck.core-profile.version>11.0.0</jakarta.tck.core-profile.version>
         <jakarta.tck.inject.version>2.0.2</jakarta.tck.inject.version>
         <jakarta-authentication-tck.version>3.1.0</jakarta-authentication-tck.version>
+        <jakarta.tck.agentic-ai.version>1.0.0-SNAPSHOT</jakarta.tck.agentic-ai.version>
         <jakarta.tck.data.version>1.0.1</jakarta.tck.data.version>
         <jakarta.tck.jms.version>3.1.0</jakarta.tck.jms.version>
         <!-- If updating this Faces TCK version - please also update the replacement poms we use under faces-tck -->
@@ -365,6 +366,7 @@
         <module>javaee-module-tck</module>
         <module>signature-tck</module>
         <module>xml-binding-tck</module>
+        <module>agentic-ai-tck</module>
     </modules>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <jakarta.tck.core-profile.version>11.0.0</jakarta.tck.core-profile.version>
         <jakarta.tck.inject.version>2.0.2</jakarta.tck.inject.version>
         <jakarta-authentication-tck.version>3.1.0</jakarta-authentication-tck.version>
-        <jakarta.tck.agentic-ai.version>1.0.0-SNAPSHOT</jakarta.tck.agentic-ai.version>
+        <jakarta.tck.agentic-ai.version>1.0.0</jakarta.tck.agentic-ai.version>
         <jakarta.tck.data.version>1.0.1</jakarta.tck.data.version>
         <jakarta.tck.jms.version>3.1.0</jakarta.tck.jms.version>
         <!-- If updating this Faces TCK version - please also update the replacement poms we use under faces-tck -->

--- a/tck-download/jakarta-agentic-ai-tck/pom.xml
+++ b/tck-download/jakarta-agentic-ai-tck/pom.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+  Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+
+  The contents of this file are subject to the terms of either the GNU
+  General Public License Version 2 only ("GPL") or the Common Development
+  and Distribution License("CDDL") (collectively, the "License").  You
+  may not use this file except in compliance with the License.  You can
+  obtain a copy of the License at
+  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  See the License for the specific
+  language governing permissions and limitations under the License.
+
+  When distributing the software, include this License Header Notice in each
+  file and include the License file at glassfish/legal/LICENSE.txt.
+
+  GPL Classpath Exception:
+  The Payara Foundation designates this particular file as subject to the "Classpath"
+  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  file that accompanied this code.
+
+  Modifications:
+  If applicable, add the following below the License Header, with the fields
+  enclosed by brackets [] replaced by your own identifying information:
+  "Portions Copyright [year] [name of copyright owner]"
+
+  Contributor(s):
+  If you wish your version of this file to be governed by only the CDDL or
+  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  elects to include this software in this distribution under the [CDDL or GPL
+  Version 2] license."  If you don't indicate a single choice of license, a
+  recipient has the option to distribute your version of this file under
+  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  its licensees as provided above.  However, if you add GPL Version 2 code
+  and therefore, elected the GPL Version 2 license, then the option applies
+  only if the new code is made subject to such option by the copyright
+  holder.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>fish.payara.jakarta.tests.tck</groupId>
+        <artifactId>tck-download</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jakarta-agentic-ai-tck</artifactId>
+    <packaging>pom</packaging>
+    <name>TCK: Install Jakarta Agentic AI TCK</name>
+
+    <properties>
+        <agentic-ai.clone.dir>${project.build.directory}${file.separator}agentic-ai</agentic-ai.clone.dir>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>clone-agentic-ai-repo</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>git</executable>
+                            <arguments>
+                                <argument>clone</argument>
+                                <argument>--depth</argument>
+                                <argument>1</argument>
+                                <argument>https://github.com/jakartaee/agentic-ai.git</argument>
+                                <argument>${agentic-ai.clone.dir}</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>build-agentic-ai-tck</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>${maven.executable}</executable>
+                            <workingDirectory>${agentic-ai.clone.dir}</workingDirectory>
+                            <arguments>
+                                <argument>install</argument>
+                                <argument>-DskipTests</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/tck-download/pom.xml
+++ b/tck-download/pom.xml
@@ -58,6 +58,7 @@
         <module>jakarta-dsol-tck</module>
         <module>jakarta-xml-binding-tck</module>
         <module>jakarta-mvc-tck</module>
+        <module>jakarta-agentic-ai-tck</module>
     </modules>
 
     <build>


### PR DESCRIPTION
…build, and test configuration for verifying Payara Server compliance

**Summary**                                                                                                                                                                                                                       
                                                                                                                                                                                                                                
- Add new tck-download/jakarta-agentic-ai-tck module to clone and build the Jakarta Agentic AI TCK from source (SNAPSHOT, not yet published)                                                                                    
- Add new agentic-ai-tck runner module with Arquillian, Failsafe, and signature test configuration for verifying Payara Server compliance                                                                                       
- Register the new modules in the root and tck-download parent POMs                                                                                                                                                             
                                                                                                                                                                                                                                
**Test plan**

- Run mvn install -pl tck-download/jakarta-agentic-ai-tck to verify the TCK repo clones and builds successfully
- Run mvn verify -pl agentic-ai-tck -Ppayara-server-remote against a running Payara Server instance
- Check agentic-ai-tck/target/failsafe-reports/ for test results