### PR TITLE
FISH-13347 Swap Ant Download URL to "archive" URL

### DIFF
--- a/cdi-platform-tck/cdi-platform-tck-docker-runner/src/main/docker/Dockerfile
+++ b/cdi-platform-tck/cdi-platform-tck-docker-runner/src/main/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM eclipsecbijenkins/basic-ubuntu-chrome
 EXPOSE 4848 5005 8080 8181 9009
 
 # Download and install Java, Maven, and Ant
-ADD https://cdn.azul.com/zulu/bin/zulu21.40.17-ca-jdk21.0.6-linux_x64.zip https://archive.apache.org/dist/maven/maven-3/3.9.10/binaries/apache-maven-3.9.10-bin.zip https://dlcdn.apache.org//ant/binaries/apache-ant-1.10.15-bin.zip /opt/
+ADD https://cdn.azul.com/zulu/bin/zulu21.40.17-ca-jdk21.0.6-linux_x64.zip https://archive.apache.org/dist/maven/maven-3/3.9.10/binaries/apache-maven-3.9.10-bin.zip https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.15-bin.zip /opt/
 WORKDIR /opt
 RUN unzip zulu21.40.17-ca-jdk21.0.6-linux_x64.zip \
     && rm zulu21.40.17-ca-jdk21.0.6-linux_x64.zip \

--- a/faces-tck/faces-tck-docker-runner/src/main/docker/Dockerfile
+++ b/faces-tck/faces-tck-docker-runner/src/main/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM eclipsecbijenkins/basic-ubuntu-chrome
 EXPOSE 4848 5005 8080 8181 9009 14848 18080 18181
 
 # Download and install Java, Maven, and Ant
-ADD https://cdn.azul.com/zulu/bin/zulu21.40.17-ca-jdk21.0.6-linux_x64.zip https://archive.apache.org/dist/maven/maven-3/3.9.10/binaries/apache-maven-3.9.10-bin.zip https://dlcdn.apache.org//ant/binaries/apache-ant-1.10.15-bin.zip /opt/
+ADD https://cdn.azul.com/zulu/bin/zulu21.40.17-ca-jdk21.0.6-linux_x64.zip https://archive.apache.org/dist/maven/maven-3/3.9.10/binaries/apache-maven-3.9.10-bin.zip https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.15-bin.zip /opt/
 WORKDIR /opt
 RUN unzip zulu21.40.17-ca-jdk21.0.6-linux_x64.zip \
     && rm zulu21.40.17-ca-jdk21.0.6-linux_x64.zip \


### PR DESCRIPTION
This should hopefully prevent the download breaking again when a new version of Ant if released

Tested here: https://jenkins.payara.fish/view/TCKs/job/TCKs/job/JakartaEE-11-TCK/139/