### PR TITLE
FISH-13126 Use New payara-acc.xml

### DIFF
--- a/assembly-platform-tck/src/test/resources/appclient-arquillian.xml
+++ b/assembly-platform-tck/src/test/resources/appclient-arquillian.xml
@@ -33,7 +33,7 @@
                 -Dri.log.file.location=${payara.home}/glassfish/domains/domain1/logs \
                 -DwebServerHost.2=localhost \
                 -DwebServerPort.2=8080 \
-                -javaagent:${payara.home}/glassfish/lib/gf-client.jar=arg=-configxml,arg=${payara.home}/glassfish/domains/domain1/config/glassfish-acc.xml,client=jar=${clientStubJar},arg=-name,arg=${clientAppArchiveName} \
+                -javaagent:${payara.home}/glassfish/lib/gf-client.jar=arg=-configxml,arg=${payara.home}/glassfish/domains/domain1/config/payara-acc.xml,client=jar=${clientStubJar},arg=-name,arg=${clientAppArchiveName} \
                 org.glassfish.appclient.client.AppClientGroupFacade
             </property>
             <property name="cmdLineArgSeparator">\\</property>

--- a/ejb-platform-tck/src/test/resources/arquillian.xml
+++ b/ejb-platform-tck/src/test/resources/arquillian.xml
@@ -53,7 +53,7 @@
                     -Dri.log.file.location=${payara.home}/glassfish/domains/domain1/logs \
                     -DwebServerHost.2=localhost \
                     -DwebServerPort.2=8080 \
-                    -javaagent:${payara.home}/glassfish/lib/gf-client.jar=arg=-configxml,arg=${payara.home}/glassfish/domains/domain1/config/glassfish-acc.xml,client=jar=${clientStubJar},arg=-name,arg=${clientAppArchiveName} \
+                    -javaagent:${payara.home}/glassfish/lib/gf-client.jar=arg=-configxml,arg=${payara.home}/glassfish/domains/domain1/config/payara-acc.xml,client=jar=${clientStubJar},arg=-name,arg=${clientAppArchiveName} \
                     org.glassfish.appclient.client.AppClientGroupFacade
                 </property>
                 <property name="cmdLineArgSeparator">\\</property>

--- a/jsonb-platform-tck/src/test/resources/appclient-arquillian.xml
+++ b/jsonb-platform-tck/src/test/resources/appclient-arquillian.xml
@@ -36,7 +36,7 @@
                 -Dri.log.file.location=${payara.home}/glassfish/domains/domain1/logs \
                 -DwebServerHost.2=localhost \
                 -DwebServerPort.2=8080 \
-                -javaagent:${payara.home}/glassfish/lib/gf-client.jar=arg=-configxml,arg=${payara.home}/glassfish/domains/domain1/config/glassfish-acc.xml,client=jar=${clientStubJar},arg=-name,arg=${clientAppArchiveName} \
+                -javaagent:${payara.home}/glassfish/lib/gf-client.jar=arg=-configxml,arg=${payara.home}/glassfish/domains/domain1/config/payara-acc.xml,client=jar=${clientStubJar},arg=-name,arg=${clientAppArchiveName} \
                 org.glassfish.appclient.client.AppClientGroupFacade
             </property>
             <property name="cmdLineArgSeparator">\\</property>

--- a/jsonp-platform-tck/src/test/resources/appclient-arquillian.xml
+++ b/jsonp-platform-tck/src/test/resources/appclient-arquillian.xml
@@ -36,7 +36,7 @@
                 -Dri.log.file.location=${payara.home}/glassfish/domains/domain1/logs \
                 -DwebServerHost.2=localhost \
                 -DwebServerPort.2=8080 \
-                -javaagent:${payara.home}/glassfish/lib/gf-client.jar=arg=-configxml,arg=${payara.home}/glassfish/domains/domain1/config/glassfish-acc.xml,client=jar=${clientStubJar},arg=-name,arg=${clientAppArchiveName} \
+                -javaagent:${payara.home}/glassfish/lib/gf-client.jar=arg=-configxml,arg=${payara.home}/glassfish/domains/domain1/config/payara-acc.xml,client=jar=${clientStubJar},arg=-name,arg=${clientAppArchiveName} \
                 org.glassfish.appclient.client.AppClientGroupFacade
             </property>
             <property name="cmdLineArgSeparator">\\</property>

--- a/persistence-platform-tck/src/test/resources/arquillian.xml
+++ b/persistence-platform-tck/src/test/resources/arquillian.xml
@@ -57,7 +57,7 @@
                     -Dri.log.file.location=${payara.home}/glassfish/domains/domain1/logs \
                     -DwebServerHost.2=localhost \
                     -DwebServerPort.2=8080 \
-                    -javaagent:${payara.home}/glassfish/lib/gf-client.jar=arg=-configxml,arg=${payara.home}/glassfish/domains/domain1/config/glassfish-acc.xml,client=jar=${clientStubJar},arg=-name,arg=${clientAppArchiveName} \
+                    -javaagent:${payara.home}/glassfish/lib/gf-client.jar=arg=-configxml,arg=${payara.home}/glassfish/domains/domain1/config/payara-acc.xml,client=jar=${clientStubJar},arg=-name,arg=${clientAppArchiveName} \
                     org.glassfish.appclient.client.AppClientGroupFacade
                 </property>
                 <property name="cmdLineArgSeparator">\\</property>


### PR DESCRIPTION
Convert the arquillian config files to use the new payara-acc.xml file - Payara 7 no longer packages glassfish-acc.xml (though should still support it)

_Note: this is a "breaking change" to the runner - it won't work against older versions of Payara 7 without changing the config files back to looking for glassfish-acc.xml_