### PR TITLE
New faster and more reliable runner for JAXB

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,124 @@
 # jakartaee-10-tck-runners
 
-Payara runners for the standalone Jakarta EE TCKs.
-See individual module READMEs for details, but general usage is:
+Payara runners for the standalone Jakarta EE TCKs. Each module integrates a Jakarta EE specification TCK with Payara Server so that compliance can be verified via Maven.
 
-`mvn clean verify -Dpayara.version=${payaraVersion} -Ppayara-server-managed -pl . -pl tck-download -pl tck-download/${tckToRun} -pl ${tckToRun}`
+## Prerequisites
+
+- **JDK 21** or later
+- **Maven 3.9+**
+- **Payara Server 7** (either downloaded automatically via the `payara-server-managed` profile, or already running for `payara-server-remote`)
+- **Unix/Linux/macOS** — the `xml-binding-tck` module does not support Windows
+
+## Repository Structure
+
+```
+jakartaee-10-tck-runners/
+├── tck-download/          # Downloads & installs TCK ZIPs into local Maven repo
+│   └── jakarta-*/         # One sub-module per TCK artifact
+├── <spec>-tck/            # Runner modules, one per Jakarta EE spec
+├── summarizer/            # Utility: aggregates TCK results into a single report
+└── pom.xml                # Root POM: dependency versions, Payara profiles
+```
+
+### `tck-download`
+
+Many TCK artifacts are not published to Maven Central and must be downloaded from the Eclipse download site and installed into the local Maven repository before the runner modules can use them. Each sub-module under `tck-download` handles one TCK.
+
+```
+mvn clean install -pl . -pl tck-download -pl tck-download/<spec>-tck -Dpayara.version=<version>
+```
+
+### Runner modules
+
+Each `<spec>-tck` module contains the Maven configuration to run the tests against a Payara Server instance. Two testing approaches are used across the modules:
+
+| Approach | Modules | Notes |
+|---|---|---|
+| **Arquillian + JUnit 5** (`maven-failsafe-plugin`) | Most TCKs (jsonb, jsonp, rest, servlet, cdi-platform, persistence, concurrent, …) | Tests run inside or against a live Payara instance via Arquillian. Supports `payara-server-managed` (Maven starts/stops Payara) and `payara-server-remote` (Payara already running). |
+| **JavaTest / JCK harness** (`run-tck.sh` shell script) | `xml-binding-tck` | Uses the legacy JavaTest harness bundled with the TCK ZIP. Maven unpacks the TCK, then invokes the shell script which drives `javatest.jar` directly. |
+
+### `summarizer`
+
+A standalone Java utility that reads test output from multiple formats (JUnit XML, `summary.txt`, `testSet`, failsafe summaries, or collections) and produces a single consolidated report. See `summarizer/README.md`.
+
+## General Usage
+
+### Managed mode (Maven controls the Payara lifecycle)
+
+```
+mvn clean verify \
+  -Ppayara-server-managed \
+  -Dpayara.version=<payara-version> \
+  -pl . -pl tck-download -pl tck-download/<spec>-tck -pl <spec>-tck
+```
+
+### Remote mode (Payara is already running)
+
+```
+mvn clean verify \
+  -Ppayara-server-remote \
+  -Dpayara.version=<payara-version> \
+  -Dpayara.home=<path-to-payara> \
+  -pl . -pl <spec>-tck
+```
+
+> **Note:** Remote mode skips the `tck-download` step, so the TCK artifact must already be in the local Maven repository.
+
+## Module Overview
+
+| Module | Jakarta EE Spec | TCK Version | Test Harness |
+|---|---|---|---|
+| `activation-tck` | Jakarta Activation | — | Arquillian/JUnit 5 |
+| `annotations-tck` | Jakarta Annotations | 3.0.0 | Arquillian/JUnit 5 |
+| `authentication-tck` | Jakarta Authentication | 3.1.0 | Arquillian/JUnit 5 |
+| `authorization-tck` | Jakarta Authorization | 3.0.0 | Arquillian/JUnit 5 |
+| `batch-tck` | Jakarta Batch | 2.1.5 | Arquillian/JUnit 5 |
+| `bean-validation-tck` | Jakarta Bean Validation | 3.1.1 | Arquillian/JUnit 5 |
+| `cdi-langmodel-tck` | CDI Language Model | — | Arquillian/JUnit 5 |
+| `cdi-platform-tck` | CDI (Platform) | 4.1.0 | Ant + Arquillian |
+| `cdi-tck` | CDI (Standalone) | 4.1.0 | Arquillian/JUnit 5 |
+| `concurrent-tck` | Jakarta Concurrency | 3.1.1 | Arquillian/JUnit 5 |
+| `core-tck` | Jakarta Core Profile | 11.0.0 | Arquillian/JUnit 5 |
+| `data-tck` | Jakarta Data | 1.0.1 | Arquillian/JUnit 5 |
+| `expression-language-tck` | Jakarta Expression Language | 6.0.0 | Arquillian/JUnit 5 |
+| `faces-tck` | Jakarta Faces | 4.1.1 | Arquillian/JUnit 5 |
+| `inject-tck` | Jakarta Inject | 2.0.2 | Arquillian/JUnit 5 |
+| `jsonb-tck` | Jakarta JSON Binding | 3.0.0 | Arquillian/JUnit 5 |
+| `jsonp-tck` | Jakarta JSON Processing | 2.1.1 | Arquillian/JUnit 5 |
+| `messaging-tck` | Jakarta Messaging | 3.1.0 | Arquillian/JUnit 5 |
+| `mvc-tck` | Jakarta MVC | 3.0.0 | Arquillian/JUnit 5 |
+| `pages-tck` | Jakarta Pages | 4.0.0 | Arquillian/JUnit 5 |
+| `persistence-tck` | Jakarta Persistence | 3.2.0 | Arquillian/JUnit 5 |
+| `rest-tck` | Jakarta REST | 4.0.0 | Arquillian/JUnit 5 |
+| `security-tck` | Jakarta Security | — | Arquillian/JUnit 5 |
+| `servlet-tck` | Jakarta Servlet | 6.1.0 | Arquillian/JUnit 5 |
+| `soap-tck` | Jakarta SOAP | — | Arquillian/JUnit 5 |
+| `tags-tck` | Jakarta Tags | — | Arquillian/JUnit 5 |
+| `transaction-platform-tck` | Jakarta Transactions | 2.0.1 | Arquillian/JUnit 5 |
+| `websocket-tck` | Jakarta WebSocket | 2.2.0 | Arquillian/JUnit 5 |
+| `xml-binding-tck` | Jakarta XML Binding | 4.0.2 | JavaTest/JCK harness (shell script) |
+| `xml-ws-tck` | Jakarta XML Web Services | — | Arquillian/JUnit 5 |
+
+Platform TCK variants (`*-platform-tck`) run the same specs inside the full Jakarta EE Platform profile.
+
+## Key Maven Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `payara.version` | `7.2025.1.Alpha4-SNAPSHOT` | Payara Server version to download/test against |
+| `payara.home` | `target/payara7` | Path to unpacked Payara installation |
+| `payara.artifact` | `payara` | Use `payara-web` for the Web Profile |
+| `jakarta.tck.platform` | `full` | Platform level: `full`, `web`, or `core` |
+| `skipTests` | `false` | Skip all test executions |
+| `skipConfig` | `${skipTests}` | Skip server configuration steps |
+| `skipServerStartStop` | `${skipTests}` | Skip starting/stopping the managed server |
+
+## Profiles
+
+| Profile | When to use |
+|---|---|
+| `payara-server-managed` | Maven downloads and manages the Payara lifecycle |
+| `payara-server-remote` | Payara is already running; tests deploy and run against it |
+| `web` | Runs the Web Profile variant of specs that support it |
+| `windows` | Activated automatically on Windows (adjusts path separators and script extensions) |
+| `payara-nexus-staging` | Enables Payara staging repository for pre-release artifacts |

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
         <jakarta.tck.transaction.version>2.0.1</jakarta.tck.transaction.version>
         <jakarta.tck.resource.version>2.1.0</jakarta.tck.resource.version>
         <jms-tck.version>11.0.0-payara</jms-tck.version>
-        <jakarta.tck.xml-binding.version>4.0.3</jakarta.tck.xml-binding.version>
+        <jakarta.tck.xml-binding.version>4.0.2</jakarta.tck.xml-binding.version>
         <jakarta.tck.mvc.version>3.0.0</jakarta.tck.mvc.version>
 
         <!-- The profile to run - acceptable parameters are 'full', 'web', and 'core' -->

--- a/xml-binding-tck/README.md
+++ b/xml-binding-tck/README.md
@@ -1,24 +1,214 @@
-# Jakarta XML Binding
+# Jakarta XML Binding TCK
+
+Runs the [Jakarta XML Binding 4.0 TCK](https://jakarta.ee/specifications/xml-binding/4.0/) against Payara Server.
+
+> **Unix/Linux/macOS only.** The test harness relies on shell scripts bundled in the TCK ZIP and cannot run on Windows.
+
+## How it works
+
+Unlike most TCK runners in this repository (which use Arquillian + JUnit 5), the XML Binding TCK uses the **legacy JavaTest / JCK harness** bundled inside the TCK ZIP. The Maven build:
+
+1. Downloads and unpacks `jakarta-xml-binding-tck-<version>.zip` into `target/`.
+2. Downloads `checker.jar` (CheckerFramework) into `target/` — required by the TCK signature tests.
+3. Invokes the runner, which configures and drives `javatest.jar` directly.
+4. At the `verify` phase, Ant checks that `<report-dir>/JAXB-TCK/text/summary.txt` contains no `Failed.` entries.
+
+By default (no profile) the Maven build calls the legacy `run-tck.sh` shell script (multi-jvm mode) — unchanged behaviour. The [fast execution modes](#fast-execution-modes) (`-Psingle-agent` / `-Pagent-pool`) instead call `RunTck.java`, a single-file Java program. We are gradually migrating off the shell script.
 
 ## Prerequisites
-Download and install the TCK from the tck-downloads module. From the top-level directory:
 
-`mvn clean install -pl . -pl tck-download -pl tck-download/jakarta-xml-binding-tck -Dpayara.version=...`
+- JDK 21+ with `JAVA_HOME` set
+- Payara Server 7 unpacked (path provided via `payara.home` or positional argument)
+- The TCK artifact installed into the local Maven repository (see below)
 
-## Test Executions
-Run maven test from the top-level directory using managed arquillian profile
+## Step 1 — Install the TCK artifact
+
+The TCK ZIP is not on Maven Central. Download it from the Eclipse download site and install it locally. From the **top-level** directory:
 
 ```
-mvn clean verify -Ppayara-server-managed -Dpayara.version=...  -pl . -pl xml-binding-tck
+mvn clean install \
+  -pl . -pl tck-download -pl tck-download/jakarta-xml-binding-tck \
+  -Dpayara.version=<version>
 ```
 
-By default this will run with a single thread. If you wish to run with more to speed up the TCK, add the 
-`-Dconcurrent.threads=x` variable to the above command with your desired number of threads.
+This downloads `jakarta-xml-binding-tck-4.0.2.zip` from `https://download.eclipse.org/jakartaee/xml-binding/4.0/` and installs it as `jakarta.tck:jakarta-xml-binding-tck:4.0.2:zip` in the local Maven repository.
 
-### Running the Script Directly
-If you wish to run the `run-tck.sh` script directly, it is written with the following assumptions:
-* It can take 0, 1, or 2 parameters
-  * Parameter one must be the path of the Payara install you wish to test
-    * If this is not provided, the script will assume the default managed arquillian location relative to the script (../target/payara7)
-  * Paramter two must be the number of concurrent threads to use
-    * If not provided, only 1 thread will be used
+## Step 2 — Run the TCK
+
+From the **top-level** directory:
+
+```
+mvn clean verify \
+  -Ppayara-server-managed \
+  -Dpayara.version=<version> \
+  -pl . -pl xml-binding-tck
+```
+
+To run with multiple concurrent threads (speeds up execution):
+
+```
+mvn clean verify \
+  -Ppayara-server-managed \
+  -Dpayara.version=<version> \
+  -Dconcurrent.threads=4 \
+  -pl . -pl xml-binding-tck
+```
+
+> `payara-server-managed` unpacks the Payara ZIP into `target/payara7` and passes that path to the runner. The XML Binding TCK does **not** deploy anything to Payara — the server is used only as a source of JAXB implementation JARs.
+
+## Fast execution modes
+
+The full TCK is dominated by ~28,000 XML Schema test groups. In the default `multi-jvm` mode every schema test group spawns **two** short-lived JVMs (one for `xjc`, one for the test executor) — on the order of ~57,000 JVM starts, which makes a full run very slow. Two faster modes run the tests inside long-lived JavaTest **agent** JVMs, where XJC/schemagen run in-process and the harness schema cache actually works.
+
+| Mode (profile) | Runner | What it does | Isolation | When to use |
+|---|---|---|---|---|
+| `multi-jvm` (default, no profile) | `run-tck.sh` | Fresh JVM per compile + per test, via bundled shell scripts | Per test (process) | Certification / reference behaviour |
+| `single-agent` (`-Psingle-agent`) | `RunTck.java` | One long-lived agent JVM, N concurrent tests in one heap | Shared heap | Fastest for dev/CI on a trusted machine |
+| `agent-pool` (`-Pagent-pool`) | `RunTck.java` | N long-lived agent JVMs, each single-threaded | Per agent (process) | Fast **and** isolated; safest fast mode |
+
+Both fast modes auto-detect concurrency from `Runtime.getRuntime().availableProcessors()`. Override with `-Dconcurrent.threads=N`.
+
+```bash
+# Single long-lived agent JVM, auto-detected concurrency
+mvn clean verify -Ppayara-server-managed,single-agent \
+  -Dpayara.version=<version> -pl . -pl xml-binding-tck
+
+# Pool of agent JVMs (one test each), explicit pool size
+mvn clean verify -Ppayara-server-managed,agent-pool \
+  -Dconcurrent.threads=8 -Dpayara.version=<version> -pl . -pl xml-binding-tck
+```
+
+Results are written to a per-mode report directory so runs can coexist:
+
+| Mode | Report dir (under `target/`) | Work dir | Archive |
+|---|---|---|---|
+| `multi-jvm` | `JAXB_REPORT/` | `batch-multiJVM/` | `jaxbtck-multi-jvm-results.tar.gz` |
+| `single-agent` | `SINGLE_AGENT_REPORT/` | `batch-singleJVM/` | `jaxbtck-single-agent-results.tar.gz` |
+| `agent-pool` | `AGENT_POOL_REPORT/` | `batch-agentPool/` | `jaxbtck-agent-pool-results.tar.gz` |
+
+> **Caveat (shared heap).** In `single-agent` mode all tests share one JVM. A few TCK statics — notably a shared `SchemaFactory` and `System.out`/`System.err` redirection during XJC — are not thread-safe, so very high concurrency in a single agent can produce flaky, non-reproducible schema failures. If you see those, prefer `agent-pool` (each JVM is single-threaded) or lower `-Dconcurrent.threads`. The JAXB RI's XJC/schemagen also require a **full JDK** (not a JRE) because schemagen runs the annotation processor via the system Java compiler.
+
+### Running `RunTck.java` directly
+
+The runner needs no compilation (JDK 11+ single-file source launch):
+
+```bash
+java RunTck.java <mode> <payara-home> <concurrency> <report-dir>
+# e.g.
+java RunTck.java single-agent ../target/payara7 0 target/SINGLE_AGENT_REPORT
+```
+
+| Argument | Description |
+|---|---|
+| `mode` | `multi-jvm`, `single-agent`, or `agent-pool` |
+| `payara-home` | Path to the Payara installation (contains `glassfish/`) |
+| `concurrency` | Number of concurrent tests; `0` = auto-detect |
+| `report-dir` | Output directory for the JavaTest report |
+
+CDS and class-unloading JVM flags for the agent JVMs are present but commented out near `startAgents` in `RunTck.java` — enable them to shave further start-up/metaspace cost on Java 21.
+
+## Legacy shell script (`run-tck.sh`)
+
+> This is the **default** runner when no profile is selected (multi-jvm mode). It is
+> functionally equivalent to `RunTck.java multi-jvm`; the fast-mode profiles use
+> `RunTck.java` instead, and we are gradually migrating the default off this script.
+
+`run-tck.sh` accepts 0, 1, or 2 positional arguments:
+
+```
+bash run-tck.sh [payara-home] [concurrent-threads]
+```
+
+| Argument | Default | Description |
+|---|---|---|
+| `payara-home` | `../target/payara7` (relative to script) | Path to the Payara installation |
+| `concurrent-threads` | `1` | Number of concurrent JavaTest threads |
+
+## What `run-tck.sh` does
+
+The script performs the following steps:
+
+### 1. Patch configuration files
+
+Two files inside the unpacked TCK are patched in-place using `sed`:
+
+**`target/xml-binding-tck/testsuite.jtt`**
+- Sets `finder` to point to the binary test index (`testsuite.jtd`) in the unpacked location.
+
+**`target/xml-binding-tck/lib/javasoft-multiJVM.jti`** (JavaTest Interview / configuration file)
+
+| Setting | Value |
+|---|---|
+| `jck.env.jaxb.classes.jaxbClasses` | Payara JAXB JARs + `checker.jar` (see below) |
+| `jck.env.jaxb.testExecute.cmdAsFile` | `$JAVA_HOME/bin/java` |
+| `WORKDIR` | `target/xml-binding-tck/batch-multiJVM/work/` |
+| `TESTSUITE` | `target/xml-binding-tck/` |
+| `jck.env.jaxb.testExecute.otherEnvVars` | `JAVA_HOME` and `JAXB_HOME` (set to `$PAYARA_HOME/glassfish`) |
+| `jck.env.jaxb.schemagen.run.jxcCmd` | `/bin/sh linux/bin/schemagen.sh` |
+| `jck.concurrency.concurrency` | `concurrent-threads` argument (if provided) |
+
+### 2. JAXB implementation JARs
+
+The following JARs from the Payara installation are placed on the TCK classpath:
+
+| JAR | Purpose |
+|---|---|
+| `glassfish/modules/jakarta.xml.bind-api.jar` | Jakarta XML Binding API |
+| `glassfish/modules/jaxb-osgi.jar` | JAXB RI (Reference Implementation) |
+| `glassfish/modules/jersey-media-jaxb.jar` | Jersey JAXB media support |
+| `glassfish/modules/jakarta.activation-api.jar` | Jakarta Activation API (required by JAXB) |
+| `target/checker.jar` | CheckerFramework (required by signature tests) |
+
+### 3. Run JavaTest in two passes
+
+**Pass 1 — full run:**
+```
+java -jar javatest.jar -batch -testsuite ... -open javasoft-multiJVM.jti \
+  -workdir -create batch-multiJVM/work \
+  -set jck.env.jaxb.xsd_compiler.skipValidationOptional Yes \
+  -set jck.env.jaxb.xsd_compiler.testCompile.xjcCmd "/bin/sh linux/bin/xjc.sh" \
+  ... -runtests
+```
+
+**Pass 2 — rerun only tests that did not run:**
+Same command, but adds `-set jck.priorStatus.status not_run` to pick up any tests skipped in pass 1.
+
+**Report generation:**
+```
+java -jar javatest.jar -workdir batch-multiJVM/work -writereport JAXB_REPORT/JAXB-TCK
+```
+
+### 4. Convert results to JUnit XML
+
+`JTReportParser.jar` (bundled in this module's root) converts the JavaTest report into JUnit XML format compatible with CI systems:
+
+```
+java -jar JTReportParser.jar args.txt JAXB_REPORT results/junitreports/
+```
+
+### 5. Archive results
+
+All output is packed into `target/jaxbtck-results.tar.gz`:
+- `JAXB_REPORT/` — JavaTest HTML and text reports
+- `batch-multiJVM/work/` — JavaTest work directory (per-test results)
+- `results/junitreports/` — JUnit XML reports
+
+## Verification
+
+After the script finishes, `maven-antrun-plugin` (in the `verify` phase) checks:
+
+```
+target/JAXB_REPORT/JAXB-TCK/text/summary.txt
+```
+
+If the file contains the string `Failed.`, the build fails. This is the primary pass/fail gate for the Maven build.
+
+## Output files
+
+| Path | Description |
+|---|---|
+| `target/JAXB_REPORT/JAXB-TCK/text/summary.txt` | Summary: passed/failed/error counts |
+| `target/JAXB_REPORT/JAXB-TCK/` | Full JavaTest HTML and text reports |
+| `target/results/junitreports/` | JUnit XML (for CI import) |
+| `target/batch-multiJVM/work/` | JavaTest work directory |
+| `target/jaxbtck-results.tar.gz` | Archive of all above |

--- a/xml-binding-tck/RunTck.java
+++ b/xml-binding-tck/RunTck.java
@@ -197,7 +197,7 @@ public class RunTck {
         try {
             switch (mode) {
                 case MULTI_JVM -> runMultiJvm();
-                case SINGLE_AGENT -> runAgents(1, effectiveConcurrency());
+                case SINGLE_AGENT -> runAgents(1, effectiveConcurrency()*2);  // 3x for single jvm. Switch to agentpool if you see concurrency issues.
                 case AGENT_POOL -> runAgents(effectiveConcurrency(), 1);
             }
         } finally {

--- a/xml-binding-tck/RunTck.java
+++ b/xml-binding-tck/RunTck.java
@@ -1,0 +1,726 @@
+/*
+ * Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Java replacement for {@code run-tck.sh} that can drive the Jakarta XML Binding
+ * TCK in three execution modes:
+ *
+ * <ul>
+ *   <li>{@code multi-jvm}    – the legacy default: a fresh JVM is spawned per
+ *       schema compile and per test execution (via the bundled shell scripts).</li>
+ *   <li>{@code single-agent} – one long-lived JavaTest agent JVM runs every test
+ *       in-process, with {@code concurrency} tests at a time. XJC/schemagen run
+ *       in-process (no shell scripts). Much faster; shares one heap.</li>
+ *   <li>{@code agent-pool}   – N long-lived agent JVMs, each single-threaded.
+ *       JVM reuse <em>with</em> process isolation; the safest fast mode.</li>
+ * </ul>
+ *
+ * <p>Run as a single-file source program:
+ * {@code java RunTck.java <mode> <payara-home> <concurrency> <report-dir> [<progress>] [<interval-sec>]}
+ * where {@code concurrency == 0} means "auto-detect from available processors",
+ * {@code progress} is {@code true/false} (default {@code false}),
+ * and {@code interval-sec} is the reporting interval in seconds (default 60).
+ *
+ * <p>See {@code src/docs/developer/vendor-speedup-guide.adoc} in the TCK sources
+ * for the rationale behind the agent modes and the shared-state caveats.
+ */
+public class RunTck {
+
+    /** TCK unpack directory name under {@code target/}. */
+    private static final String TCK_NAME = "xml-binding-tck";
+
+    // -----------------------------------------------------------------------
+    // JAXB implementation JARs supplied by Payara (glassfish/modules/).
+    // These are the most likely things to change when upgrading Payara or
+    // switching to a different JAXB implementation.
+    // -----------------------------------------------------------------------
+    private static final List<String> SERVER_JARS = List.of(
+            "jakarta.xml.bind-api.jar",
+            "jaxb-osgi.jar",
+            "jersey-media-jaxb.jar",
+            "jakarta.activation-api.jar"
+    );
+    /** CheckerFramework JAR — required by the TCK signature tests. Lives in target/, not modules/. */
+    private static final String JAR_CHECKER = "checker.jar";
+
+    enum Mode {
+        MULTI_JVM("multi-jvm", "javasoft-multiJVM.jti", "batch-multiJVM"),
+        SINGLE_AGENT("single-agent", "javasoft-singleJVM.jti", "batch-singleJVM"),
+        AGENT_POOL("agent-pool", "javasoft-singleJVM.jti", "batch-agentPool");
+
+        final String id;
+        final String jti;
+        final String batchDir;
+
+        Mode(String id, String jti, String batchDir) {
+            this.id = id;
+            this.jti = jti;
+            this.batchDir = batchDir;
+        }
+
+        static Mode of(String id) {
+            for (Mode m : values()) {
+                if (m.id.equals(id)) {
+                    return m;
+                }
+            }
+            throw new IllegalArgumentException("Unknown mode '" + id
+                    + "'. Expected one of: multi-jvm, single-agent, agent-pool");
+        }
+    }
+
+    private final Mode mode;
+    private final Path payaraHome;
+    private final Path glassfishHome;
+    private final int requestedConcurrency;
+    private final Path reportDir;
+
+    private final Path workspace;        // .../xml-binding-tck/target
+    private final Path tckDir;           // .../target/xml-binding-tck
+    private final Path jtiFile;          // .../target/xml-binding-tck/lib/<mode jti>
+    private final Path javatestJar;      // .../target/xml-binding-tck/lib/javatest.jar
+    private final Path batchWork;        // .../target/<batchDir>/work
+
+    /** Whether to print a pass/fail summary at regular intervals while tests run. */
+    private final boolean progress;
+    /** How often to print the progress summary, in seconds. */
+    private final int progressIntervalSec;
+
+    RunTck(String[] args) {
+        if (args.length < 4) {
+            throw new IllegalArgumentException(
+                    "Usage: java RunTck.java <mode> <payara-home> <concurrency> <report-dir>"
+                    + " [<progress:true|false>] [<interval-sec>]");
+        }
+        this.mode = Mode.of(args[0]);
+        this.payaraHome = Path.of(args[1]).toAbsolutePath().normalize();
+        this.glassfishHome = payaraHome.resolve("glassfish");
+        this.requestedConcurrency = Integer.parseInt(args[2].trim());
+        this.reportDir = Path.of(args[3]).toAbsolutePath().normalize();
+        this.progress = args.length >= 5 && Boolean.parseBoolean(args[4].trim());
+        this.progressIntervalSec = args.length >= 6 ? Integer.parseInt(args[5].trim()) : 60;
+
+        // The script lives in the module root; target/ is its working area.
+        Path moduleDir = Path.of(System.getProperty("user.dir")).toAbsolutePath();
+        this.workspace = moduleDir.resolve("target");
+        this.tckDir = workspace.resolve(TCK_NAME);
+        this.jtiFile = tckDir.resolve("lib").resolve(mode.jti);
+        this.javatestJar = tckDir.resolve("lib").resolve("javatest.jar");
+        this.batchWork = workspace.resolve(mode.batchDir).resolve("work");
+    }
+
+    public static void main(String[] args) throws Exception {
+        RunTck runner = new RunTck(args);
+        runner.run();
+    }
+
+    private void run() throws Exception {
+        System.out.println("=== Jakarta XML Binding TCK runner ===");
+        System.out.println("mode        : " + mode.id);
+        System.out.println("payara home : " + payaraHome);
+        System.out.println("concurrency : " + effectiveConcurrency()
+                + (requestedConcurrency == 0 ? " (auto-detected)" : ""));
+        System.out.println("report dir  : " + reportDir);
+        System.out.println("workspace   : " + workspace);
+        System.out.println("progress    : " + (progress
+                ? "enabled (every " + progressIntervalSec + "s)" : "disabled"));
+
+        if (mode == Mode.MULTI_JVM && isWindows()) {
+            throw new UnsupportedOperationException(
+                    "multi-jvm mode relies on the bundled shell scripts and cannot run on Windows. "
+                    + "Use -Psingle-agent or -Pagent-pool instead.");
+        }
+
+        patchTestsuiteFinder();
+
+        // Guard used by both the shutdown hook and the normal finally path to
+        // ensure report generation runs exactly once — whichever gets there first.
+        AtomicBoolean reportDone = new AtomicBoolean(false);
+
+        // Generate a partial JUnit report when the process is killed with SIGINT
+        // (Ctrl+C).  SIGINT also kills the child JavaTest process, so waitFor()
+        // returns, the finally block runs — but if the JVM itself has started
+        // shutting down before the finally completes, the hook is the safety net.
+        Thread exitHook = new Thread(() -> {
+            if (reportDone.compareAndSet(false, true)) {
+                System.out.println("\n[exit] Writing partial report...");
+                try { writeReport(); } catch (Exception e) { System.err.println(e.getMessage()); }
+                try { convertToJUnit(); } catch (Exception e) { System.err.println(e.getMessage()); }
+            }
+        }, "tck-exit-report");
+        Runtime.getRuntime().addShutdownHook(exitHook);
+
+        Thread readerThread   = null;
+        Thread reporterThread = null;
+        ProgressReporter reporter = null;
+        if (progress) {
+            BlockingQueue<String> queue = new LinkedBlockingQueue<>();
+            reporter      = new ProgressReporter(queue, progressIntervalSec);
+            readerThread  = new Thread(
+                    new TraceReader(batchWork.resolve("jtData").resolve("harness.trace"), queue),
+                    "tck-trace-reader");
+            reporterThread = new Thread(reporter, "tck-progress-reporter");
+            readerThread.setDaemon(true);
+            reporterThread.setDaemon(true);
+            readerThread.start();
+            reporterThread.start();
+        }
+        try {
+            switch (mode) {
+                case MULTI_JVM -> runMultiJvm();
+                case SINGLE_AGENT -> runAgents(1, effectiveConcurrency());
+                case AGENT_POOL -> runAgents(effectiveConcurrency(), 1);
+            }
+        } finally {
+            if (readerThread != null) {
+                readerThread.interrupt();
+                try { Thread.sleep(200); } catch (InterruptedException ignored) {}
+                reporter.report();
+                reporterThread.interrupt();
+            }
+            // Deregister the hook; if the JVM is already shutting down the
+            // removeShutdownHook call itself will throw — that means the hook
+            // will handle report generation, so we skip it here.
+            boolean hookRemoved = false;
+            try {
+                hookRemoved = Runtime.getRuntime().removeShutdownHook(exitHook);
+            } catch (IllegalStateException ignored) { /* JVM already shutting down */ }
+
+            if (hookRemoved && reportDone.compareAndSet(false, true)) {
+                writeReport();
+                convertToJUnit();
+                archive();
+                System.out.println("=== TCK run complete: report at " + reportDir + " ===");
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Mode runners
+    // ------------------------------------------------------------------
+
+    private void runMultiJvm() throws Exception {
+        Map<String, String> p = new LinkedHashMap<>();
+        p.put("TESTSUITE", tckDir + "/");
+        p.put("WORKDIR", batchWork + "/");
+        p.put("jck.env.jaxb.testExecute.cmdAsFile", javaExecutable().toString());
+        p.put("jck.env.jaxb.testExecute.otherEnvVars", envVars());
+        p.put("jck.env.jaxb.xsd_compiler.testCompile.xjcCmd", xjcCmd());
+        p.put("jck.env.jaxb.schemagen.run.jxcCmd", schemagenCmd());
+        p.put("jck.env.jaxb.classes.jaxbClasses", jaxbClassesSpaceSeparated());
+        p.put("jck.env.jaxb.classes.needJaxbClasses", "Yes");
+        p.put("jck.concurrency.concurrency", Integer.toString(effectiveConcurrency()));
+        patchProperties(jtiFile, p);
+
+        runTests(/* create */ true, /* notRunOnly */ false, /* agentPort */ -1);
+        runTests(/* create */ false, /* notRunOnly */ true, /* agentPort */ -1);
+    }
+
+    /**
+     * Agent-based execution (single-agent and agent-pool share this path).
+     *
+     * @param agentCount       number of agent JVMs to start
+     * @param agentConcurrency tests each agent runs at once
+     */
+    private void runAgents(int agentCount, int agentConcurrency) throws Exception {
+        int harnessConcurrency = agentCount * agentConcurrency;
+
+        Map<String, String> p = new LinkedHashMap<>();
+        p.put("TESTSUITE", tckDir + "/");
+        p.put("WORKDIR", batchWork + "/");
+        p.put("jck.env.jaxb.testExecute.cmdAsFile", javaExecutable().toString());
+        p.put("jck.env.jaxb.testExecute.otherEnvVars", envVars());
+        p.put("jck.concurrency.concurrency", Integer.toString(harnessConcurrency));
+        patchProperties(jtiFile, p);
+
+        int port = findFreePort();
+        System.out.println("agent pool port : " + port);
+        System.out.println("starting " + agentCount + " agent JVM(s), concurrency "
+                + agentConcurrency + " each");
+
+        List<Process> agents = startAgents(port, agentCount, agentConcurrency);
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            for (Process a : agents) {
+                a.destroy();
+            }
+        }));
+
+        // Give the agents a moment to connect to the pool before JavaTest starts
+        // dispatching work to it.
+        Thread.sleep(2000L);
+
+        try {
+            runTests(/* create */ true, /* notRunOnly */ false, port);
+            runTests(/* create */ false, /* notRunOnly */ true, port);
+        } finally {
+            for (Process a : agents) {
+                a.destroy();
+            }
+        }
+    }
+
+    private List<Process> startAgents(int port, int agentCount, int agentConcurrency)
+            throws IOException {
+        String agentCp = String.join(File.pathSeparator,
+                javatestJar.toString(),
+                tckDir.resolve("classes").toString(),
+                jaxbClassesPathSeparated(),
+                workspace.resolve("checker.jar").toString());
+
+        // Suppress the chatty JUL INFO messages from DirsClassLoader.newInstance()
+        // (and any other verbose INFO logging in the agent JVMs) by writing a
+        // minimal logging.properties that raises the console threshold to WARNING.
+        Path loggingConfig = workspace.resolve("agent-logging.properties");
+        if (!Files.exists(loggingConfig)) {
+            Files.writeString(loggingConfig,
+                    "handlers=java.util.logging.ConsoleHandler\n"
+                    + ".level=WARNING\n"
+                    + "java.util.logging.ConsoleHandler.level=WARNING\n"
+                    + "java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter\n");
+        }
+
+        List<Process> agents = new ArrayList<>();
+        for (int i = 0; i < agentCount; i++) {
+            List<String> cmd = new ArrayList<>();
+            cmd.add(javaExecutable().toString());
+            cmd.add("-cp");
+            cmd.add(agentCp);
+            cmd.add("-Djava.security.policy=" + tckDir.resolve("lib").resolve("tck.policy"));
+            cmd.add("-Djava.util.logging.config.file=" + loggingConfig);
+            // --- Java 21 tuning (uncomment to enable) ---
+            // Reuse an application class-data archive to cut agent start-up cost.
+            // cmd.add("-XX:+AutoCreateSharedArchive");
+            // cmd.add("-XX:SharedArchiveFile=" + workspace.resolve("jaxbtck-agent-" + i + ".jsa"));
+            // Reclaim per-test class loaders concurrently instead of the harness's
+            // periodic System.gc() crutch.
+            // cmd.add("-XX:+ClassUnloadingWithConcurrentMark");
+            cmd.add("com.sun.javatest.agent.AgentMain");
+            cmd.add("-activeHost");
+            cmd.add("localhost");
+            cmd.add("-activePort");
+            cmd.add(Integer.toString(port));
+            cmd.add("-concurrency");
+            cmd.add(Integer.toString(agentConcurrency));
+
+            // Run agents from the signaturetest directory so that SigTestWrapper
+            // can resolve the bare relative path "sig/jakarta.xml.bind.sig" it
+            // constructs.  All other tests receive absolute paths via the harness
+            // environment macros, so the cwd does not affect them.
+            ProcessBuilder pb = new ProcessBuilder(cmd)
+                    .directory(tckDir.resolve("tests").resolve("api")
+                                     .resolve("signaturetest").toFile())
+                    .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+                    .redirectError(ProcessBuilder.Redirect.INHERIT);
+            pb.environment().put("JAVA_HOME", javaHome().toString());
+            pb.environment().put("JAXB_HOME", glassfishHome.toString());
+            // SchemaGenerator (schemagen / jxc) reads Options.classpath from
+            // System.getenv("CLASSPATH") on Java 11+ where AppClassLoader is
+            // no longer a URLClassLoader and the TCCL walk in setClasspath()
+            // finds nothing.  Explicitly setting CLASSPATH here ensures that
+            // jakarta.activation-api.jar (and everything else) is visible to
+            // javac when schemagen compiles the Java sources in-process.
+            pb.environment().put("CLASSPATH", agentCp);
+            agents.add(pb.start());
+        }
+        return agents;
+    }
+
+    // ------------------------------------------------------------------
+    // JavaTest invocation
+    // ------------------------------------------------------------------
+
+    private void runTests(boolean createWorkDir, boolean notRunOnly, int agentPort)
+            throws Exception {
+        List<String> cmd = new ArrayList<>();
+        cmd.add(javaExecutable().toString());
+        cmd.add("-jar");
+        cmd.add(javatestJar.toString());
+        cmd.add("-batch");
+        cmd.add("-testsuite");
+        cmd.add(tckDir.toString());
+        cmd.add("-open");
+        cmd.add(jtiFile.toString());
+
+        if (agentPort > 0) {
+            cmd.add("-startAgentPool");
+            cmd.add("-agentPoolPort");
+            cmd.add(Integer.toString(agentPort));
+        }
+
+        cmd.add("-workdir");
+        if (createWorkDir) {
+            cmd.add("-create");
+        }
+        cmd.add(batchWork.toString());
+
+        cmd.add("-set");
+        cmd.add("jck.env.jaxb.xsd_compiler.skipValidationOptional");
+        cmd.add("Yes");
+
+        if (notRunOnly) {
+            cmd.add("-set");
+            cmd.add("jck.priorStatus.needStatus");
+            cmd.add("Yes");
+            cmd.add("-set");
+            cmd.add("jck.priorStatus.status");
+            cmd.add("not_run");
+        }
+
+        cmd.add("-runtests");
+
+        System.out.println((notRunOnly ? "--- JavaTest pass 2 (rerun not_run) ---"
+                                       : "--- JavaTest pass 1 (full run) ---"));
+
+        // run-tck.sh cds into tests/api/signaturetest/ before launching JavaTest.
+        // SigTestWrapper builds a bare relative path  "sig/jakarta.xml.bind.sig"
+        // and passes it straight to the sigtest tool, so the JVM working directory
+        // must be that directory for the path to resolve.  All other tests receive
+        // absolute paths via $testSuiteRootDir / TestURL, so this is harmless.
+        exec(cmd, tckDir.resolve("tests").resolve("api").resolve("signaturetest"));
+    }
+
+    private void writeReport() throws Exception {
+        Files.createDirectories(reportDir.resolve("JAXB-TCK"));
+        exec(List.of(
+                javaExecutable().toString(),
+                "-jar", javatestJar.toString(),
+                "-workdir", batchWork.toString(),
+                "-writereport", reportDir.resolve("JAXB-TCK").toString()));
+    }
+
+    private void convertToJUnit() throws Exception {
+        Path parser = workspace.getParent().resolve("JTReportParser.jar");
+        if (!Files.exists(parser)) {
+            System.out.println("JTReportParser.jar not found at " + parser + " - skipping JUnit conversion");
+            return;
+        }
+        Path junitDir = workspace.resolve("results").resolve("junitreports");
+        Files.createDirectories(junitDir);
+
+        String host = hostname();
+        Path argsFile = workspace.resolve("args.txt");
+        Files.writeString(argsFile, "1 JAXB-TCK " + host + System.lineSeparator());
+
+        exec(List.of(
+                javaExecutable().toString(),
+                "-Djunit.embed.sysout=true",
+                "-jar", parser.toString(),
+                argsFile.toString(),
+                reportDir.toString(),
+                junitDir.toString()));
+
+        Files.deleteIfExists(argsFile);
+    }
+
+    private void archive() throws Exception {
+        Path tarball = workspace.resolve("jaxbtck-" + mode.id + "-results.tar.gz");
+        List<String> cmd = new ArrayList<>(List.of(
+                "tar", "zcf", tarball.toString(),
+                reportDir.toString(),
+                batchWork.getParent().toString()));
+        Path junit = workspace.resolve("results").resolve("junitreports");
+        if (Files.exists(junit)) {
+            cmd.add(junit.toString());
+        }
+        try {
+            exec(cmd);
+        } catch (Exception e) {
+            System.out.println("Archiving failed (non-fatal): " + e.getMessage());
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Progress monitoring — producer / consumer
+    // ------------------------------------------------------------------
+
+    /**
+     * Continuously tails {@code harness.trace} and puts each new line into the
+     * shared queue. Blocks for 100 ms when at the current EOF so it does not
+     * busy-spin. Uses {@link RandomAccessFile} because {@link java.io.BufferedReader}
+     * / {@link java.io.InputStreamReader} cache the EOF state and stop retrying
+     * once they see it, which makes them unsuitable for tailing a growing file.
+     */
+    private static class TraceReader implements Runnable {
+        private final Path trace;
+        private final BlockingQueue<String> queue;
+
+        TraceReader(Path trace, BlockingQueue<String> queue) {
+            this.trace = trace;
+            this.queue = queue;
+        }
+
+        @Override
+        public void run() {
+            // Wait until JavaTest creates the file (typically within the first few seconds).
+            while (!Thread.currentThread().isInterrupted() && !Files.exists(trace)) {
+                try { Thread.sleep(500); } catch (InterruptedException e) { return; }
+            }
+            if (Thread.currentThread().isInterrupted()) return;
+
+            try (RandomAccessFile raf = new RandomAccessFile(trace.toFile(), "r")) {
+                while (!Thread.currentThread().isInterrupted()) {
+                    String line = raf.readLine();
+                    if (line != null) {
+                        queue.put(line);
+                    } else {
+                        Thread.sleep(100);   // at EOF — wait for more content
+                    }
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (IOException e) {
+                System.out.println("[progress] trace reader error: " + e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Drains the shared line queue every {@code intervalSec} seconds, updates
+     * cumulative pass/fail/error counters, and prints a one-line summary plus any
+     * new failures recorded in that interval. Suppresses output when nothing
+     * has changed since the last print (so the final flush after the run does not
+     * produce a duplicate line).
+     */
+    private static class ProgressReporter implements Runnable {
+        private final BlockingQueue<String> queue;
+        private final int intervalSec;
+
+        private long totalPassed    = 0;
+        private long totalFailed    = 0;
+        private long totalError     = 0;
+        private long lastPrintTotal = 0;   // 0 = nothing printed yet; suppresses empty early ticks
+
+        ProgressReporter(BlockingQueue<String> queue, int intervalSec) {
+            this.queue = queue;
+            this.intervalSec = intervalSec;
+        }
+
+        @Override
+        public void run() {
+            while (!Thread.currentThread().isInterrupted()) {
+                try {
+                    Thread.sleep(intervalSec * 1000L);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                report();
+            }
+        }
+
+        /** Drain the queue, update counters, print if anything changed. */
+        void report() {
+            List<String> batch = new ArrayList<>();
+            queue.drainTo(batch);
+
+            List<String> newFailures = new ArrayList<>();
+            for (String line : batch) {
+                if (!line.contains("Finished:")) continue;
+                if      (line.contains(": Passed")) { totalPassed++; }
+                else if (line.contains(": Failed")) { totalFailed++; newFailures.add(line); }
+                else if (line.contains(": Error"))  { totalError++;  newFailures.add(line); }
+            }
+
+            long total = totalPassed + totalFailed + totalError;
+            if (total == 0 || total == lastPrintTotal) return;   // nothing to show
+            lastPrintTotal = total;
+
+            System.out.printf("[progress %s]  passed=%-6d  failed=%-4d  error=%-4d  total=%d%n",
+                    LocalTime.now().withNano(0), totalPassed, totalFailed, totalError, total);
+
+            for (String line : newFailures) {
+                // Strip leading timestamp; keep "Finished: (N s) path: Failed. reason"
+                int idx = line.indexOf(" Finished:");
+                System.out.println("  FAIL: " + (idx >= 0 ? line.substring(idx + 1) : line));
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // File patching
+    // ------------------------------------------------------------------
+
+    /** Patch the {@code finder=} line of {@code testsuite.jtt} to the unpacked location. */
+    private void patchTestsuiteFinder() throws IOException {
+        Path jtt = tckDir.resolve("testsuite.jtt");
+        String finder = "com.sun.javatest.finder.BinaryTestFinder -binary "
+                + tckDir.resolve("tests").resolve("testsuite.jtd");
+        patchProperties(jtt, Map.of("finder", finder));
+    }
+
+    /**
+     * Replace {@code key=...} lines in a {@code key=value} file, preserving order,
+     * comments and any keys not mentioned. Keys absent from the file are appended.
+     */
+    private void patchProperties(Path file, Map<String, String> replacements) throws IOException {
+        List<String> lines = Files.readAllLines(file);
+        Map<String, String> remaining = new LinkedHashMap<>(replacements);
+        List<String> out = new ArrayList<>(lines.size());
+
+        for (String line : lines) {
+            String replaced = null;
+            for (Map.Entry<String, String> e : replacements.entrySet()) {
+                if (line.startsWith(e.getKey() + "=")) {
+                    replaced = e.getKey() + "=" + e.getValue();
+                    remaining.remove(e.getKey());
+                    break;
+                }
+            }
+            out.add(replaced != null ? replaced : line);
+        }
+        // Append any keys that were not already present.
+        for (Map.Entry<String, String> e : remaining.entrySet()) {
+            out.add(e.getKey() + "=" + e.getValue());
+        }
+
+        Files.write(file, out);
+        System.out.println("patched " + file.getFileName() + ": " + replacements.keySet());
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private int effectiveConcurrency() {
+        return requestedConcurrency > 0
+                ? requestedConcurrency
+                : Runtime.getRuntime().availableProcessors();
+    }
+
+    private int findFreePort() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+
+    /** JAXB implementation JARs, space-separated (JTI {@code jaxbClasses} format). */
+    private String jaxbClassesSpaceSeparated() {
+        return String.join(" ", jaxbJars());
+    }
+
+    /** JAXB implementation JARs, path-separator-separated (JVM {@code -cp} format). */
+    private String jaxbClassesPathSeparated() {
+        return String.join(File.pathSeparator, jaxbJars());
+    }
+
+    private List<String> jaxbJars() {
+        Path modules = glassfishHome.resolve("modules");
+        List<String> jars = new ArrayList<>();
+        for (String jar : SERVER_JARS) {
+            jars.add(modules.resolve(jar).toString());
+        }
+        jars.add(workspace.resolve(JAR_CHECKER).toString());
+        return jars;
+    }
+
+    /** {@code otherEnvVars} value in JTI format: {@code =} inside values is escaped as {@code \=}. */
+    private String envVars() {
+        return "JAVA_HOME\\=" + javaHome() + " JAXB_HOME\\=" + glassfishHome;
+    }
+
+    private String xjcCmd() {
+        return osShell() + tckDir.resolve(osBinDir()).resolve(osScript("xjc"));
+    }
+
+    private String schemagenCmd() {
+        return osShell() + tckDir.resolve(osBinDir()).resolve(osScript("schemagen"));
+    }
+
+    private String osBinDir() {
+        String os = osName();
+        if (os.contains("win")) {
+            return "win32/bin";
+        }
+        if (os.contains("mac") || os.contains("darwin")) {
+            return "macos/bin";
+        }
+        if (os.contains("sunos") || os.contains("solaris")) {
+            return "solaris/bin";
+        }
+        return "linux/bin";
+    }
+
+    private String osScript(String tool) {
+        return isWindows() ? tool + ".bat" : tool + ".sh";
+    }
+
+    /** Shell prefix for invoking the tool script (empty on Windows, which runs .bat directly). */
+    private String osShell() {
+        if (isWindows()) {
+            return "";
+        }
+        String os = osName();
+        return (os.contains("sunos") || os.contains("solaris")) ? "/bin/ksh " : "/bin/sh ";
+    }
+
+    private Path javaHome() {
+        return Path.of(System.getProperty("java.home"));
+    }
+
+    private Path javaExecutable() {
+        return javaHome().resolve("bin").resolve(isWindows() ? "java.exe" : "java");
+    }
+
+    private String hostname() {
+        try {
+            return InetAddress.getLocalHost().getCanonicalHostName();
+        } catch (Exception e) {
+            return "localhost";
+        }
+    }
+
+    private static String osName() {
+        return System.getProperty("os.name").toLowerCase();
+    }
+
+    private static boolean isWindows() {
+        return osName().contains("win");
+    }
+
+    private void exec(List<String> cmd) throws Exception {
+        exec(cmd, workspace);
+    }
+
+    private void exec(List<String> cmd, Path workDir) throws Exception {
+        System.out.println("+ " + String.join(" ", cmd));
+        ProcessBuilder pb = new ProcessBuilder(cmd)
+                .directory(workDir.toFile())
+                .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+                .redirectError(ProcessBuilder.Redirect.INHERIT);
+        pb.environment().put("JAVA_HOME", javaHome().toString());
+        pb.environment().put("JAXB_HOME", glassfishHome.toString());
+        pb.environment().put("JAVA_TOOL_OPTIONS", "-Dfile.encoding=UTF8");
+        int rc = pb.start().waitFor();
+        if (rc != 0) {
+            System.out.println("command exited with code " + rc);
+        }
+    }
+}

--- a/xml-binding-tck/pom.xml
+++ b/xml-binding-tck/pom.xml
@@ -13,12 +13,38 @@
     <packaging>pom</packaging>
 
     <properties>
-        <scriptExecutor>bash</scriptExecutor>
-        <scriptExtension>sh</scriptExtension>
-
         <checker.version>3.5.0</checker.version>
 
+        <!--
+            Default: legacy shell script (multi-jvm mode), unchanged behaviour.
+            The single-agent / agent-pool profiles flip tck.skip.shell=true and
+            tck.skip.java=${skipTests} so only the Java runner executes.
+            We are gradually migrating off the shell script.
+        -->
+        <tck.skip.shell>${skipTests}</tck.skip.shell>
+        <tck.skip.java>true</tck.skip.java>
+
+        <!-- Overridden by fast-mode profiles. -->
+        <tck.mode>multi-jvm</tck.mode>
+        <tck.report.dir>JAXB_REPORT</tck.report.dir>
+
+        <!--
+            Number of concurrent tests / agent JVMs.
+            Default 1 preserves existing multi-jvm behaviour.
+            Fast-mode profiles set 0 = auto-detect (Runtime.availableProcessors).
+        -->
         <concurrent.threads>1</concurrent.threads>
+
+        <!--
+            Progress reporting. Set tck.progress=true to print a cumulative
+            pass/fail/error summary to the console at regular intervals while
+            tests are running. tck.progress.interval controls how often in
+            seconds (default 60 = every minute).
+
+            Example: -Dtck.progress=true -Dtck.progress.interval=30
+        -->
+        <tck.progress>false</tck.progress>
+        <tck.progress.interval>60</tck.progress.interval>
     </properties>
 
     <dependencies>
@@ -39,27 +65,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>enforce-os</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <requireOS>
-                                    <family>unix</family>
-                                    <message>You cannot run this TCK on Windows</message>
-                                </requireOS>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
@@ -111,20 +116,57 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <executions>
+                    <!--
+                        Default runner: legacy shell script (multi-jvm).
+                        Skipped by the fast-mode profiles via tck.skip.shell=true.
+                        Note: multi-jvm still requires a Unix-like OS because of the bundled shell
+                        scripts. The OS guard lives in RunTck.java for the Java-based modes.
+                    -->
                     <execution>
-                        <id>run-tck</id>
+                        <id>run-tck-shell</id>
                         <phase>integration-test</phase>
                         <goals>
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <skip>${skipTests}</skip>
-                            <executable>${scriptExecutor}</executable>
-                            <commandlineArgs>${basedir}${file.separator}run-tck.${scriptExtension} ${payara.home} ${concurrent.threads}</commandlineArgs>
+                            <skip>${tck.skip.shell}</skip>
+                            <executable>bash</executable>
+                            <arguments>
+                                <argument>${basedir}/run-tck.sh</argument>
+                                <argument>${payara.home}</argument>
+                                <argument>${concurrent.threads}</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+
+                    <!--
+                        Fast-mode runner: RunTck.java single-file Java program.
+                        Activated by the single-agent / agent-pool profiles via tck.skip.java=${skipTests}.
+                        Supports multi-jvm, single-agent, and agent-pool modes.
+                    -->
+                    <execution>
+                        <id>run-tck-java</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${tck.skip.java}</skip>
+                            <executable>${java.home}/bin/java</executable>
+                            <arguments>
+                                <argument>${basedir}/RunTck.java</argument>
+                                <argument>${tck.mode}</argument>
+                                <argument>${payara.home}</argument>
+                                <argument>${concurrent.threads}</argument>
+                                <argument>${project.build.directory}/${tck.report.dir}</argument>
+                                <argument>${tck.progress}</argument>
+                                <argument>${tck.progress.interval}</argument>
+                            </arguments>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
@@ -138,10 +180,12 @@
                         <configuration>
                             <skip>${skipTests}</skip>
                             <target>
-                                <echo>Checking if ${project.build.directory}${file.separator}JAXB_REPORT${file.separator}JAXB-TCK${file.separator}text${file.separator}summary.txt contains failures or errors</echo>
-                                <fail message = "summary.txt contains 'Failed.'!">
+                                <echo>Checking ${project.build.directory}/${tck.report.dir}/JAXB-TCK/text/summary.txt for failures</echo>
+                                <fail message="summary.txt contains 'Failed.'!">
                                     <condition>
-                                        <resourcecontains resource="${project.build.directory}${file.separator}JAXB_REPORT${file.separator}JAXB-TCK${file.separator}text${file.separator}summary.txt" substring="Failed."/>
+                                        <resourcecontains
+                                            resource="${project.build.directory}/${tck.report.dir}/JAXB-TCK/text/summary.txt"
+                                            substring="Failed."/>
                                     </condition>
                                 </fail>
                             </target>
@@ -151,5 +195,67 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!--
+            Execution mode profiles. Profiles only set properties — no plugin/execution
+            overrides — to avoid Maven's execution-merge behaviour which caused the
+            base commandlineArgs to bleed into the profile's java invocation.
+
+            Agent modes auto-detect concurrency (concurrent.threads=0);
+            override with -Dconcurrent.threads=N.
+
+            See README.md and src/docs/developer/vendor-speedup-guide.adoc for details.
+        -->
+        <profile>
+            <!--
+                RunTck.java-driven multi-jvm mode. Functionally equivalent to the
+                default run-tck.sh path but adds the progress indicator, graceful
+                SIGINT report, and a dedicated MULTI_JVM_REPORT directory so all
+                three modes can be compared side-by-side.
+            -->
+            <id>multi-jvm</id>
+            <properties>
+                <tck.skip.shell>true</tck.skip.shell>
+                <tck.skip.java>${skipTests}</tck.skip.java>
+                <tck.mode>multi-jvm</tck.mode>
+                <tck.report.dir>MULTI_JVM_REPORT</tck.report.dir>
+                <!-- concurrent.threads intentionally kept at the default (1).
+                     Override with -Dconcurrent.threads=N to parallelise. -->
+            </properties>
+        </profile>
+
+        <profile>
+            <!-- One long-lived JavaTest agent JVM; N concurrent tests in one heap. -->
+            <id>single-agent</id>
+            <properties>
+                <tck.skip.shell>true</tck.skip.shell>
+                <tck.skip.java>${skipTests}</tck.skip.java>
+                <tck.mode>single-agent</tck.mode>
+                <tck.report.dir>SINGLE_AGENT_REPORT</tck.report.dir>
+                <concurrent.threads>0</concurrent.threads>
+            </properties>
+        </profile>
+
+        <profile>
+            <!-- N long-lived agent JVMs, each single-threaded: JVM reuse with process isolation. -->
+            <id>agent-pool</id>
+            <properties>
+                <tck.skip.shell>true</tck.skip.shell>
+                <tck.skip.java>${skipTests}</tck.skip.java>
+                <tck.mode>agent-pool</tck.mode>
+                <tck.report.dir>AGENT_POOL_REPORT</tck.report.dir>
+                <concurrent.threads>0</concurrent.threads>
+            </properties>
+        </profile>
+        <profile>
+            <!-- Frequent status update -->
+            <id>interactive</id>
+            <properties>
+                <tck.progress>true</tck.progress>
+                <tck.progress.interval>5</tck.progress.interval>
+            </properties>
+        </profile>
+    </profiles>
 
 </project>

--- a/xml-binding-tck/pom.xml
+++ b/xml-binding-tck/pom.xml
@@ -16,24 +16,20 @@
         <checker.version>3.5.0</checker.version>
 
         <!--
-            Default: legacy shell script (multi-jvm mode), unchanged behaviour.
-            The single-agent / agent-pool profiles flip tck.skip.shell=true and
-            tck.skip.java=${skipTests} so only the Java runner executes.
-            We are gradually migrating off the shell script.
+            Default mode: single-agent (RunTck.java).
+            Use -Plegacy to fall back to the original run-tck.sh shell script.
         -->
-        <tck.skip.shell>${skipTests}</tck.skip.shell>
-        <tck.skip.java>true</tck.skip.java>
-
-        <!-- Overridden by fast-mode profiles. -->
-        <tck.mode>multi-jvm</tck.mode>
-        <tck.report.dir>JAXB_REPORT</tck.report.dir>
+        <tck.skip.shell>true</tck.skip.shell>
+        <tck.skip.java>${skipTests}</tck.skip.java>
+        <tck.mode>single-agent</tck.mode>
+        <tck.report.dir>SINGLE_AGENT_REPORT</tck.report.dir>
 
         <!--
             Number of concurrent tests / agent JVMs.
-            Default 1 preserves existing multi-jvm behaviour.
-            Fast-mode profiles set 0 = auto-detect (Runtime.availableProcessors).
+            0 = auto-detect from Runtime.availableProcessors() (default for agent modes).
+            Override with -Dconcurrent.threads=N.
         -->
-        <concurrent.threads>1</concurrent.threads>
+        <concurrent.threads>0</concurrent.threads>
 
         <!--
             Progress reporting. Set tck.progress=true to print a cumulative
@@ -43,7 +39,7 @@
 
             Example: -Dtck.progress=true -Dtck.progress.interval=30
         -->
-        <tck.progress>false</tck.progress>
+        <tck.progress>true</tck.progress>
         <tck.progress.interval>60</tck.progress.interval>
     </properties>
 
@@ -117,10 +113,11 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <executions>
                     <!--
-                        Default runner: legacy shell script (multi-jvm).
-                        Skipped by the fast-mode profiles via tck.skip.shell=true.
-                        Note: multi-jvm still requires a Unix-like OS because of the bundled shell
-                        scripts. The OS guard lives in RunTck.java for the Java-based modes.
+                        Legacy runner: original run-tck.sh shell script (multi-jvm).
+                        Activated only by the -Plegacy profile (tck.skip.shell=${skipTests}).
+                        Skipped by default and by all other profiles (tck.skip.shell=true).
+                        Note: multi-jvm still requires a Unix-like OS because of the bundled
+                        shell scripts. The OS guard lives in RunTck.java for Java-based modes.
                     -->
                     <execution>
                         <id>run-tck-shell</id>
@@ -209,8 +206,43 @@
         -->
         <profile>
             <!--
+                Legacy mode: original run-tck.sh shell script, multi-jvm.
+                Restores the behaviour that was the default before single-agent
+                became the default.  Use when you need a certified, unmodified
+                harness invocation, or on a system where the Java runner is
+                not yet validated.
+            -->
+            <id>legacy</id>
+            <properties>
+                <tck.skip.shell>${skipTests}</tck.skip.shell>
+                <tck.skip.java>true</tck.skip.java>
+                <tck.mode>multi-jvm</tck.mode>
+                <tck.report.dir>JAXB_REPORT</tck.report.dir>
+                <concurrent.threads>1</concurrent.threads>
+            </properties>
+        </profile>
+
+        <profile>
+            <!--
+                Single-agent mode (explicit). This is also the default when no
+                profile is specified — the explicit profile is kept for symmetry
+                and to make the intent clear in CI scripts.
+                One long-lived JavaTest agent JVM; N concurrent tests in one heap.
+            -->
+            <id>single-agent</id>
+            <properties>
+                <tck.skip.shell>true</tck.skip.shell>
+                <tck.skip.java>${skipTests}</tck.skip.java>
+                <tck.mode>single-agent</tck.mode>
+                <tck.report.dir>SINGLE_AGENT_REPORT</tck.report.dir>
+                <concurrent.threads>0</concurrent.threads>
+            </properties>
+        </profile>
+
+        <profile>
+            <!--
                 RunTck.java-driven multi-jvm mode. Functionally equivalent to the
-                default run-tck.sh path but adds the progress indicator, graceful
+                legacy run-tck.sh path but adds the progress indicator, graceful
                 SIGINT report, and a dedicated MULTI_JVM_REPORT directory so all
                 three modes can be compared side-by-side.
             -->
@@ -222,18 +254,7 @@
                 <tck.report.dir>MULTI_JVM_REPORT</tck.report.dir>
                 <!-- concurrent.threads intentionally kept at the default (1).
                      Override with -Dconcurrent.threads=N to parallelise. -->
-            </properties>
-        </profile>
-
-        <profile>
-            <!-- One long-lived JavaTest agent JVM; N concurrent tests in one heap. -->
-            <id>single-agent</id>
-            <properties>
-                <tck.skip.shell>true</tck.skip.shell>
-                <tck.skip.java>${skipTests}</tck.skip.java>
-                <tck.mode>single-agent</tck.mode>
-                <tck.report.dir>SINGLE_AGENT_REPORT</tck.report.dir>
-                <concurrent.threads>0</concurrent.threads>
+                <concurrent.threads>1</concurrent.threads>
             </properties>
         </profile>
 

--- a/xml-binding-tck/pom.xml
+++ b/xml-binding-tck/pom.xml
@@ -22,7 +22,7 @@
         <tck.skip.shell>true</tck.skip.shell>
         <tck.skip.java>${skipTests}</tck.skip.java>
         <tck.mode>single-agent</tck.mode>
-        <tck.report.dir>SINGLE_AGENT_REPORT</tck.report.dir>
+        <tck.report.dir>JAXB_REPORT</tck.report.dir>
 
         <!--
             Number of concurrent tests / agent JVMs.
@@ -217,7 +217,6 @@
                 <tck.skip.shell>${skipTests}</tck.skip.shell>
                 <tck.skip.java>true</tck.skip.java>
                 <tck.mode>multi-jvm</tck.mode>
-                <tck.report.dir>JAXB_REPORT</tck.report.dir>
                 <concurrent.threads>1</concurrent.threads>
             </properties>
         </profile>
@@ -234,7 +233,6 @@
                 <tck.skip.shell>true</tck.skip.shell>
                 <tck.skip.java>${skipTests}</tck.skip.java>
                 <tck.mode>single-agent</tck.mode>
-                <tck.report.dir>SINGLE_AGENT_REPORT</tck.report.dir>
                 <concurrent.threads>0</concurrent.threads>
             </properties>
         </profile>
@@ -251,7 +249,6 @@
                 <tck.skip.shell>true</tck.skip.shell>
                 <tck.skip.java>${skipTests}</tck.skip.java>
                 <tck.mode>multi-jvm</tck.mode>
-                <tck.report.dir>MULTI_JVM_REPORT</tck.report.dir>
                 <!-- concurrent.threads intentionally kept at the default (1).
                      Override with -Dconcurrent.threads=N to parallelise. -->
                 <concurrent.threads>1</concurrent.threads>
@@ -265,7 +262,6 @@
                 <tck.skip.shell>true</tck.skip.shell>
                 <tck.skip.java>${skipTests}</tck.skip.java>
                 <tck.mode>agent-pool</tck.mode>
-                <tck.report.dir>AGENT_POOL_REPORT</tck.report.dir>
                 <concurrent.threads>0</concurrent.threads>
             </properties>
         </profile>


### PR DESCRIPTION
This adds new single-file Java runner, which can execute the TCK in two parallel modes:

* single-agent runs single JVM with multiple threads. There's potential for some crosstalk between tests, but it hasn't been observed
* agent-pool runs muliple JVM with each JVM executing single test. Safer, a little bit slower.

The runner also tracks progress and gives indication on standard output.

Measured improvement on my machine (with 12 cores) is roughly **15x**. Observed runtime for the test is around 18 minutes.