### PR TITLE
FISH-13908: run payara-micro-tests REST and DI only when payara-micro-managed profile is active

### DIFF
--- a/inject-tck/pom.xml
+++ b/inject-tck/pom.xml
@@ -51,10 +51,6 @@
     <artifactId>inject-tck</artifactId>
     <packaging>pom</packaging>
 
-    <modules>
-        <module>payara-micro-tests</module>
-    </modules>
-
     <profiles>
         <profile>
             <id>payara-micro-managed</id>
@@ -63,6 +59,9 @@
                     <name>payara.micro.managed</name>
                 </property>
             </activation>
+            <modules>
+                <module>payara-micro-tests</module>
+            </modules>
             <build>
                 <plugins>
                     <!-- Skip the Ant-based server TCK scripts when running against Micro -->

--- a/rest-tck/pom.xml
+++ b/rest-tck/pom.xml
@@ -14,7 +14,6 @@
 
     <modules>
         <module>payara-server-remote-tests</module>
-        <module>payara-micro-tests</module>
         <!-- Disabled by default until port conflict issue is resolved -->
         <!--<module>se-tests</module>-->
     </modules>
@@ -29,6 +28,9 @@
     <profiles>
         <profile>
             <id>payara-micro-managed</id>
+            <modules>
+                <module>payara-micro-tests</module>
+            </modules>
             <properties>
                 <payara.micro.jar>${maven.multiModuleProjectDirectory}${file.separator}target${file.separator}payara-micro-${payara.version}.jar</payara.micro.jar>
             </properties>


### PR DESCRIPTION
inject-tck/payara-micro-tests and rest-tck/payara-micro-tests were unconditionally declared as top-level <modules>, causing Maven to attempt resolving their dependencies (including jakarta.inject:jakarta.inject-tck:2.0.2, which is not published to Maven Central) on every build — even when the Micro profile was not active. This caused CI failures on builds that never intended to run Micro tests.


Jenkins run: https://jenkins.payara.fish/blue/organizations/jenkins/TCKs%2FJakartaEE-11-TCK/detail/JakartaEE-11-TCK/292/pipeline