### PR TITLE
FISH-13708 : build only api and tck modules of the Agentic AI clone

### DIFF
--- a/tck-download/jakarta-agentic-ai-tck/pom.xml
+++ b/tck-download/jakarta-agentic-ai-tck/pom.xml
@@ -91,6 +91,12 @@
                             <arguments>
                                 <argument>install</argument>
                                 <argument>-DskipTests</argument>
+                                <!-- Only the api and tck modules are needed to run the TCK.
+                                     Skip spec (asciidoctor plugin requires Maven 3.8.8+) and
+                                     examples, which are irrelevant here and fail on the CI Maven. -->
+                                <argument>-pl</argument>
+                                <argument>api,tck</argument>
+                                <argument>-am</argument>
                             </arguments>
                         </configuration>
                     </execution>


### PR DESCRIPTION
The `tck-download/jakarta-agentic-ai-tck` module clones `jakartaee/agentic-ai` and runs `mvn install` over the whole reactor. That reactor includes the `spec` module, whose `asciidoctor-maven-plugin:3.2.0` requires **Maven 3.8.8+**, while the Payara CI runs **Maven 3.6.3** — so the install fails:

```
The plugin org.asciidoctor:asciidoctor-maven-plugin:3.2.0 requires Maven version 3.8.8
```

Only `api` and `tck` are needed to run the TCK. This limits the clone build to `-pl api,tck -am`, skipping `spec` (docs) and `examples`.

Verified locally: `mvn install -DskipTests -pl api,tck -am` builds Parent + API + TCK successfully.