### PR TITLE
Signal Agentic AI implementation presence to the managed server (CDI 4.0 TCK)

### DIFF
--- a/agentic-ai-tck/pom.xml
+++ b/agentic-ai-tck/pom.xml
@@ -104,6 +104,47 @@
 
     <build>
         <plugins>
+            <!--
+                The Agentic AI TCK's ImplementationPresentCondition enables the
+                @RequiresImplementation assertions only when the system property
+                jakarta.ai.agent.tck.implementation.present=true is set in the
+                container (server) JVM, where it is read via Boolean.getBoolean(...).
+                The managed Arquillian adapter ignores javaVmArguments, so the option
+                is baked into the domain via asadmin before the tests start it.
+                Skipped for the payara-server-remote profile (skipConfig=true), where
+                the running server must set the property itself.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>signal-agentic-ai-implementation-present</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipConfig}</skip>
+                            <target>
+                                <exec executable="${payara.asadmin}" failonerror="false">
+                                    <arg value="start-domain"/>
+                                    <env key="AS_JAVA" value="${java.home}"/>
+                                </exec>
+                                <exec executable="${payara.asadmin}" failonerror="false">
+                                    <arg value="create-jvm-options"/>
+                                    <arg value="-Djakarta.ai.agent.tck.implementation.present=true"/>
+                                    <env key="AS_JAVA" value="${java.home}"/>
+                                </exec>
+                                <exec executable="${payara.asadmin}" failonerror="false">
+                                    <arg value="stop-domain"/>
+                                    <env key="AS_JAVA" value="${java.home}"/>
+                                </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>


### PR DESCRIPTION
## Description

The Jakarta Agentic AI TCK (aligned to the Jakarta EE 10 / CDI 4.0 baseline) detects a compatible implementation via the system property `jakarta.ai.agent.tck.implementation.present`, read **in-container** with `Boolean.getBoolean(...)`. Only when it is `true` do the `@RequiresImplementation` behavior assertions run; otherwise the `@RequiresNoImplementation` plain-CDI baseline runs instead.

In `payara-server-managed` mode the server is a separate JVM that only picks up JVM options from `domain.xml`, and the managed Arquillian adapter **ignores** `javaVmArguments` (it is reported as "Unused property entries"). So the property never reached the server JVM: the runner ran the wrong assertion set — the `@RequiresNoImplementation` baseline ran and failed (Payara correctly dispatches the full workflow), while the real `@RequiresImplementation` assertions were skipped.

This bakes the option into the domain via `asadmin create-jvm-options` in a `pre-integration-test` step (`start-domain` → `create-jvm-options` → `stop-domain`), before Arquillian starts the domain for the tests. The `exec` steps use `failonerror="false"` for idempotency across reruns, and the whole execution is gated by `skipConfig`, so the `payara-server-remote` profile (where the already-running server sets the property itself) is unaffected.

## Testing

CI-faithful run `mvn -B clean verify -Ppayara-server-managed -Dpayara.version=7.2026.8-SNAPSHOT -pl . -pl agentic-ai-tck` (fresh unpack of the distribution, `pre-integration-test` bakes the option, Arquillian starts the domain with it):

```
Tests run: 181, Failures: 0, Errors: 0, Skipped: 24
BUILD SUCCESS
```

The 24 skipped are the `@RequiresNoImplementation` baseline assertions (correctly skipped when a compatible implementation is present); all `@RequiresImplementation` behavior assertions run and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
