### PR TITLE
FISH-13908: Add Payara Micro Managed profile to Jakarta EE 11 Core Profile TCK runners

### DIFF
--- a/jsonb-tck/pom.xml
+++ b/jsonb-tck/pom.xml
@@ -164,6 +164,9 @@
                         <signature.sigTestClasspath>${payara.json-bind-api.jar}${path.separator}${jimage.dir}${file.separator}java.base${path.separator}${jimage.dir}${file.separator}java.rmi${path.separator}${jimage.dir}${file.separator}java.sql${path.separator}${jimage.dir}${file.separator}java.naming</signature.sigTestClasspath>
                         <arquillian.launch>${payara.arquillian.qualifier}</arquillian.launch>
                     </systemPropertyVariables>
+                    <environmentVariables>
+                        <JAVA_TOOL_OPTIONS>-Djava.locale.providers=COMPAT</JAVA_TOOL_OPTIONS>
+                    </environmentVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/rest-tck/payara-micro-tests/pom.xml
+++ b/rest-tck/payara-micro-tests/pom.xml
@@ -199,6 +199,9 @@
                                 <signature.sigTestClasspath>${project.build.directory}${file.separator}dependency${file.separator}jakarta.ws.rs-api.jar${path.separator}${project.build.directory}${file.separator}dependency${file.separator}jakarta.xml.bind-api.jar${path.separator}${jimage.dir}${file.separator}java.base${path.separator}${jimage.dir}${file.separator}java.rmi${path.separator}${jimage.dir}${file.separator}java.sql${path.separator}${jimage.dir}${file.separator}java.naming</signature.sigTestClasspath>
 
                                 <payara.micro.jar>${payara.micro.jar}</payara.micro.jar>
+                                <!-- Path to post-boot commands file; resolved by Arquillian from system properties
+                                     and substituted into extraMicroOptions in arquillian.xml -->
+                                <payara.micro.preboot.file>${project.build.testOutputDirectory}/preboot-commands.txt</payara.micro.preboot.file>
 
                                 <!-- Enable ServiceLoader-based JUnit 5 extension auto-detection so
                                      MicroPortCleanupExtension (in META-INF/services/) is picked up -->

--- a/rest-tck/payara-micro-tests/src/test/resources/arquillian.xml
+++ b/rest-tck/payara-micro-tests/src/test/resources/arquillian.xml
@@ -5,7 +5,7 @@
     <container qualifier="payara-micro" default="true">
         <configuration>
             <property name="microJar">${payara.micro.jar}</property>
-            <property name="extraMicroOptions">--port 8080</property>
+            <property name="extraMicroOptions">--port 8080 --prebootcommandfile ${payara.micro.preboot.file}</property>
             <property name="javaVmArguments">-Xmx256m</property>
             <property name="startupTimeoutInSeconds">120</property>
             <property name="outputToConsole">true</property>

--- a/rest-tck/payara-micro-tests/src/test/resources/preboot-commands.txt
+++ b/rest-tck/payara-micro-tests/src/test/resources/preboot-commands.txt
@@ -1,0 +1,1 @@
+set configs.config.server-config.network-config.protocols.protocol.http-listener.http.trace-enabled=true


### PR DESCRIPTION
## Summary

  Introduces a `payara-micro-managed` Maven activation profile that runs the Jakarta EE 11 Core Profile TCKs against Payara Micro using the Arquillian Managed adapter. This allows CI to validate Core Profile compliance on Payara Micro without requiring a pre-running server.

  ### TCKs added/updated for Payara Micro Managed
  
  | TCK | Change |
  |-----|--------|
  | `rest-tck` | New `payara-micro-tests` submodule with port-cleanup extension and Arquillian managed config |
  | `inject-tck` | New `payara-micro-tests` submodule with custom Arquillian extension for `@Inject` TCK |
  | `cdi-tck` | Added `micro` source set with Payara Micro-specific SPI implementations |
  | `cdi-langmodel-tck` | Updated to support `payara-micro-managed` profile |
  | `jsonb-tck` | Fixed execution under `payara-micro-managed` profile (FISH-14075) |
  | `jsonp-tck` | Added `payara-micro-managed` profile support |
  | `annotations-tck` | Added `payara-micro-managed` profile support |

### Testing
https://jenkins.payara.fish/blue/organizations/jenkins/Development-Testing%2FFISH-14076-Development/detail/FISH-14076-Development/20/pipeline/