### PR TITLE
FISH-14193 : remove hardcoded Yasson version from agentic-ai TCK runner

### DIFF
--- a/agentic-ai-tck/pom.xml
+++ b/agentic-ai-tck/pom.xml
@@ -113,7 +113,6 @@
         <dependency>
             <groupId>org.eclipse</groupId>
             <artifactId>yasson</artifactId>
-            <version>3.0.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Summary
The Agentic AI TCK runner explicitly overrode Yasson with version `3.0.3`, even though `payara-bom` already manages it. This removes the hardcoded version so it inherits the BOM-managed version, aligning the test classpath with the implementation the server actually bundles.

## Details
- `payara-bom` (7.2026.6) manages `org.eclipse:yasson` at **3.0.4**.
- The server distribution bundles Yasson **3.0.4** (confirmed via `yasson.jar` `MANIFEST.MF` → `Bundle-Version: 3.0.4`).
- The runner was pinned to **3.0.3**, a misalignment that can hide errors.

Follow-up to #213, which introduced the Yasson dependency (commit adding JSON-B to the agentic-ai TCK runner test classpath).

## Change
Removed `<version>3.0.3</version>` from the Yasson dependency in `agentic-ai-tck/pom.xml`, letting it resolve to 3.0.4 via the imported `payara-bom`.

JIRA: https://azul.atlassian.net/browse/FISH-14193

🤖 Generated with [Claude Code](https://claude.com/claude-code)