### PR TITLE
FISH-14194 : pull Agentic AI TCK from Maven Central instead of rebuilding from git clone

### DIFF
--- a/tck-download/jakarta-agentic-ai-tck/pom.xml
+++ b/tck-download/jakarta-agentic-ai-tck/pom.xml
@@ -52,52 +52,170 @@
     <packaging>pom</packaging>
     <name>TCK: Install Jakarta Agentic AI TCK</name>
 
+    <!--
+        Unlike most other Jakarta EE TCKs, the Agentic AI TCK is not distributed as
+        a ZIP on the Eclipse download site. Its 1.0.0-M1 artifacts (parent POM, API
+        and TCK) are published to Maven Central instead. This module downloads those
+        published artifacts from Maven Central and installs them into the local Maven
+        repository, so the runner consumes the exact ratified bits (matching SHAs)
+        rather than rebuilding them from a git clone.
+    -->
     <properties>
-        <agentic-ai.clone.dir>${project.build.directory}${file.separator}agentic-ai</agentic-ai.clone.dir>
+        <agentic-ai.tck.version>${jakarta.tck.agentic-ai.version}</agentic-ai.tck.version>
+        <agentic-ai.api.version>${jakarta.agentic-ai.api.version}</agentic-ai.api.version>
+        <agentic-ai.central.base>https://repo.maven.apache.org/maven2/jakarta/agentic-ai</agentic-ai.central.base>
+
+        <agentic-ai.parent.pom>jakarta.agentic-ai-parent-${agentic-ai.tck.version}.pom</agentic-ai.parent.pom>
+        <agentic-ai.api.pom>jakarta.agentic-ai-api-${agentic-ai.api.version}.pom</agentic-ai.api.pom>
+        <agentic-ai.api.jar>jakarta.agentic-ai-api-${agentic-ai.api.version}.jar</agentic-ai.api.jar>
+        <agentic-ai.api.sources>jakarta.agentic-ai-api-${agentic-ai.api.version}-sources.jar</agentic-ai.api.sources>
+        <agentic-ai.tck.pom>jakarta.agentic-ai-tck-${agentic-ai.tck.version}.pom</agentic-ai.tck.pom>
+        <agentic-ai.tck.jar>jakarta.agentic-ai-tck-${agentic-ai.tck.version}.jar</agentic-ai.tck.jar>
+        <agentic-ai.tck.sources>jakarta.agentic-ai-tck-${agentic-ai.tck.version}-sources.jar</agentic-ai.tck.sources>
     </properties>
 
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
+                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <artifactId>download-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>clone-agentic-ai-repo</id>
-                        <phase>generate-resources</phase>
+                        <id>download-agentic-ai-parent-pom</id>
                         <goals>
-                            <goal>exec</goal>
+                            <goal>wget</goal>
                         </goals>
+                        <phase>generate-resources</phase>
                         <configuration>
-                            <executable>git</executable>
-                            <arguments>
-                                <argument>clone</argument>
-                                <argument>--depth</argument>
-                                <argument>1</argument>
-                                <argument>https://github.com/jakartaee/agentic-ai.git</argument>
-                                <argument>${agentic-ai.clone.dir}</argument>
-                            </arguments>
+                            <url>${agentic-ai.central.base}/jakarta.agentic-ai-parent/${agentic-ai.tck.version}/${agentic-ai.parent.pom}</url>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                            <outputFileName>${agentic-ai.parent.pom}</outputFileName>
                         </configuration>
                     </execution>
                     <execution>
-                        <id>build-agentic-ai-tck</id>
+                        <id>download-agentic-ai-api-pom</id>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <url>${agentic-ai.central.base}/jakarta.agentic-ai-api/${agentic-ai.api.version}/${agentic-ai.api.pom}</url>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                            <outputFileName>${agentic-ai.api.pom}</outputFileName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>download-agentic-ai-api-jar</id>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <url>${agentic-ai.central.base}/jakarta.agentic-ai-api/${agentic-ai.api.version}/${agentic-ai.api.jar}</url>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                            <outputFileName>${agentic-ai.api.jar}</outputFileName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>download-agentic-ai-api-sources</id>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <url>${agentic-ai.central.base}/jakarta.agentic-ai-api/${agentic-ai.api.version}/${agentic-ai.api.sources}</url>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                            <outputFileName>${agentic-ai.api.sources}</outputFileName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>download-agentic-ai-tck-pom</id>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <url>${agentic-ai.central.base}/jakarta.agentic-ai-tck/${agentic-ai.tck.version}/${agentic-ai.tck.pom}</url>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                            <outputFileName>${agentic-ai.tck.pom}</outputFileName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>download-agentic-ai-tck-jar</id>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <url>${agentic-ai.central.base}/jakarta.agentic-ai-tck/${agentic-ai.tck.version}/${agentic-ai.tck.jar}</url>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                            <outputFileName>${agentic-ai.tck.jar}</outputFileName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>download-agentic-ai-tck-sources</id>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <url>${agentic-ai.central.base}/jakarta.agentic-ai-tck/${agentic-ai.tck.version}/${agentic-ai.tck.sources}</url>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                            <outputFileName>${agentic-ai.tck.sources}</outputFileName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-install-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>install-agentic-ai-parent-pom</id>
                         <phase>process-resources</phase>
                         <goals>
-                            <goal>exec</goal>
+                            <goal>install-file</goal>
                         </goals>
                         <configuration>
-                            <executable>${maven.executable}</executable>
-                            <workingDirectory>${agentic-ai.clone.dir}</workingDirectory>
-                            <arguments>
-                                <argument>install</argument>
-                                <argument>-DskipTests</argument>
-                                <!-- Only the api and tck modules are needed to run the TCK.
-                                     Skip spec (asciidoctor plugin requires Maven 3.8.8+) and
-                                     examples, which are irrelevant here and fail on the CI Maven. -->
-                                <argument>-pl</argument>
-                                <argument>api,tck</argument>
-                                <argument>-am</argument>
-                            </arguments>
+                            <file>${project.build.directory}${file.separator}${agentic-ai.parent.pom}</file>
+                            <pomFile>${project.build.directory}${file.separator}${agentic-ai.parent.pom}</pomFile>
+                            <groupId>jakarta.agentic-ai</groupId>
+                            <artifactId>jakarta.agentic-ai-parent</artifactId>
+                            <version>${agentic-ai.tck.version}</version>
+                            <packaging>pom</packaging>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>install-agentic-ai-api</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                        <configuration>
+                            <file>${project.build.directory}${file.separator}${agentic-ai.api.jar}</file>
+                            <pomFile>${project.build.directory}${file.separator}${agentic-ai.api.pom}</pomFile>
+                            <sources>${project.build.directory}${file.separator}${agentic-ai.api.sources}</sources>
+                            <groupId>jakarta.agentic-ai</groupId>
+                            <artifactId>jakarta.agentic-ai-api</artifactId>
+                            <version>${agentic-ai.api.version}</version>
+                            <packaging>jar</packaging>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>install-agentic-ai-tck</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                        <configuration>
+                            <file>${project.build.directory}${file.separator}${agentic-ai.tck.jar}</file>
+                            <pomFile>${project.build.directory}${file.separator}${agentic-ai.tck.pom}</pomFile>
+                            <sources>${project.build.directory}${file.separator}${agentic-ai.tck.sources}</sources>
+                            <groupId>jakarta.agentic-ai</groupId>
+                            <artifactId>jakarta.agentic-ai-tck</artifactId>
+                            <version>${agentic-ai.tck.version}</version>
+                            <packaging>jar</packaging>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
## Summary

The Agentic AI TCK download module previously cloned the git repo and rebuilt everything (including the API), which meant it used unpublished versions and produced artifacts whose SHAs would not match, making it unusable for ratification (FISH-14194).

This rewrites the module to pull the **published** artifacts instead.

Note: unlike the other Jakarta EE TCKs, the Agentic AI TCK is not distributed as a ZIP on the Eclipse download site (`download.eclipse.org/jakartaee/agentic-ai` returns 404). Its published `1.0.0-M1` artifacts (parent POM, API and TCK) are on Maven Central, so that is the published-downloads source used here.

## Changes

The module now:
- Downloads the published `1.0.0-M1` artifacts (parent POM, API jar/pom/sources, TCK jar/pom/sources) from Maven Central via `download-maven-plugin`.
- Installs them into the local Maven repository via `maven-install-plugin` (`install-file`), mirroring the other download modules.

## Validation

- Download module builds cleanly and installs all artifacts into `~/.m2`.
- The installed TCK jar SHA1 matches the one published on Maven Central (`290f00b9c80964cc45ce608296d9accd1a71ecbd`), so it can be used to ratify.
- The `agentic-ai-tck` runner resolves all dependencies offline from the local repository.

Addresses both concerns in the ticket: (a) published versions are used rather than a rebuild, and (b) the SHAs match.